### PR TITLE
Game Demo: Phase 2 — Settlement growth, workers & resource gathering

### DIFF
--- a/game-demo/index.html
+++ b/game-demo/index.html
@@ -181,6 +181,41 @@
             min-width: 24px;
         }
 
+        /* Population bar */
+        #pop-bar {
+            position: fixed;
+            top: 3.5rem;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 10;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 0.35rem 1rem;
+            display: none;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.8rem;
+        }
+
+        #pop-bar.visible {
+            display: flex;
+        }
+
+        .pop-label {
+            color: var(--muted);
+        }
+
+        .pop-number {
+            color: var(--accent);
+            font-weight: 600;
+        }
+
+        .pop-sep {
+            color: var(--border);
+            margin: 0 0.2rem;
+        }
+
         /* Turn counter */
         #turn-counter {
             position: fixed;
@@ -241,6 +276,36 @@
             transform: scale(0.97);
         }
 
+        /* Save/Load bar */
+        #save-load-bar {
+            position: fixed;
+            bottom: 1rem;
+            right: 10rem;
+            z-index: 10;
+            display: none;
+            gap: 0.4rem;
+        }
+
+        #save-load-bar.visible {
+            display: flex;
+        }
+
+        #save-load-bar button {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 0.4rem 0.8rem;
+            font-size: 0.8rem;
+            font-family: inherit;
+            color: var(--text);
+            cursor: pointer;
+            transition: border-color 0.2s;
+        }
+
+        #save-load-bar button:hover {
+            border-color: var(--accent);
+        }
+
         /* Build menu panel */
         #build-menu {
             position: fixed;
@@ -252,6 +317,7 @@
             border-radius: 8px;
             padding: 0.8rem;
             min-width: 220px;
+            max-width: 260px;
             max-height: 400px;
             overflow-y: auto;
             display: none;
@@ -309,8 +375,77 @@
             margin-top: 0.15rem;
         }
 
+        .terrain-bonus {
+            color: #4ade80;
+        }
+
         .cost-short {
             color: #ef4444;
+        }
+
+        /* Worker panel in build menu */
+        .worker-panel {
+            margin-top: 0.5rem;
+            padding-top: 0.4rem;
+            border-top: 1px solid var(--border);
+            font-size: 0.8rem;
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            flex-wrap: wrap;
+        }
+
+        .worker-label {
+            color: var(--muted);
+        }
+
+        .worker-btn {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            color: var(--accent);
+            font-weight: 700;
+            font-size: 0.85rem;
+            width: 24px;
+            height: 24px;
+            cursor: pointer;
+            font-family: inherit;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: border-color 0.2s;
+        }
+
+        .worker-btn:hover {
+            border-color: var(--accent);
+        }
+
+        .worker-warn {
+            color: #ef4444;
+            font-size: 0.7rem;
+        }
+
+        /* Upgrade button */
+        .upgrade-btn {
+            margin-top: 0.5rem;
+        }
+
+        /* Minimap */
+        #minimap {
+            position: fixed;
+            bottom: 5rem;
+            left: 1rem;
+            z-index: 10;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 0.4rem;
+        }
+
+        #minimap-canvas {
+            display: block;
+            border-radius: 4px;
+            image-rendering: pixelated;
         }
 
         /* Race selection overlay */
@@ -385,6 +520,31 @@
             color: var(--accent-dim);
         }
 
+        /* Continue button */
+        #continue-btn {
+            display: none;
+            margin-top: 1rem;
+            background: var(--surface);
+            border: 2px solid var(--accent-dim);
+            border-radius: 8px;
+            padding: 0.7rem 2rem;
+            color: var(--accent);
+            font-size: 1rem;
+            font-weight: 600;
+            font-family: inherit;
+            cursor: pointer;
+            transition: border-color 0.2s, transform 0.1s;
+        }
+
+        #continue-btn.visible {
+            display: block;
+        }
+
+        #continue-btn:hover {
+            border-color: var(--accent);
+            transform: translateY(-2px);
+        }
+
         @media (max-width: 600px) {
             .race-options {
                 flex-direction: column;
@@ -395,6 +555,10 @@
                 font-size: 0.75rem;
                 gap: 0.5rem;
                 padding: 0.4rem 0.8rem;
+            }
+
+            #minimap {
+                display: none;
             }
         }
     </style>
@@ -423,6 +587,7 @@
                 <div class="race-bonus">+50% Stone</div>
             </button>
         </div>
+        <button id="continue-btn">Continue Saved Game</button>
     </div>
 
     <div class="hud-header">
@@ -434,6 +599,9 @@
     <!-- Resource HUD bar -->
     <div id="resource-bar"></div>
 
+    <!-- Population bar -->
+    <div id="pop-bar"></div>
+
     <!-- Turn counter -->
     <div id="turn-counter">
         <span class="turn-label">Turn</span>
@@ -442,6 +610,12 @@
 
     <!-- End Turn button -->
     <button id="end-turn-btn">End Turn</button>
+
+    <!-- Save/Load -->
+    <div id="save-load-bar">
+        <button id="save-btn">Save</button>
+        <button id="load-btn">Load</button>
+    </div>
 
     <!-- Build menu (shown when hex selected) -->
     <div id="build-menu"></div>
@@ -454,6 +628,11 @@
     </div>
 
     <div id="hex-info"></div>
+
+    <!-- Minimap -->
+    <div id="minimap">
+        <canvas id="minimap-canvas" width="120" height="120"></canvas>
+    </div>
 
     <script type="importmap">
     {

--- a/game-demo/js/input.js
+++ b/game-demo/js/input.js
@@ -67,10 +67,20 @@ export function setupInput(camera, hexMeshes, hexData, callbacks) {
 
         if (data.building) {
             const def = BUILDING_TYPES[data.building.type];
+            const level = data.building.level || 1;
+            const levelStr = level > 1 ? ' Lv.' + level : '';
             const status = data.building.turnsRemaining > 0
                 ? ' (building: ' + data.building.turnsRemaining + ' turns)'
                 : '';
-            html += '<div class="hex-building">' + def.name + status + '</div>';
+            html += '<div class="hex-building">' + def.name + levelStr + status + '</div>';
+        }
+
+        if (data.improvement) {
+            if (data.improvement.turnsRemaining > 0) {
+                html += '<div class="hex-building">Improving: ' + data.improvement.turnsRemaining + ' turns left</div>';
+            } else {
+                html += '<div class="hex-building">Improved</div>';
+            }
         }
 
         overlay.innerHTML = html;
@@ -126,7 +136,10 @@ export function setupInput(camera, hexMeshes, hexData, callbacks) {
             event.target.closest('#end-turn-btn') ||
             event.target.closest('#race-select') ||
             event.target.closest('#resource-bar') ||
-            event.target.closest('#turn-counter')) {
+            event.target.closest('#turn-counter') ||
+            event.target.closest('#pop-bar') ||
+            event.target.closest('#save-load-bar') ||
+            event.target.closest('#minimap')) {
             return;
         }
 

--- a/game-demo/js/main.js
+++ b/game-demo/js/main.js
@@ -1,12 +1,12 @@
 // main.js — Entry point for the hex grid game demo
 
 import * as THREE from 'three';
-import { createHexGrid } from './hex-grid.js';
+import { createHexGrid, axialToWorld, TERRAIN } from './hex-grid.js';
 import { setupCamera } from './camera.js';
 import { setupInput } from './input.js';
-import { createGameState, addBuilding } from './game-state.js';
-import { RESOURCE_INFO, RESOURCE_TYPES } from './resources.js';
-import { BUILDING_TYPES, canPlaceBuilding, deductCost, createBuildingMesh, updateBuildingMesh } from './buildings.js';
+import { createGameState, addBuilding, getAvailableWorkers, getAssignedWorkers, startHexImprovement, saveGame, loadGame, hasSavedGame, deleteSavedGame } from './game-state.js';
+import { RESOURCE_INFO, RESOURCE_TYPES, TERRAIN_BONUSES } from './resources.js';
+import { BUILDING_TYPES, canPlaceBuilding, canUpgradeBuilding, deductCost, deductUpgradeCost, createBuildingMesh, recalcPopulationCap, UPGRADE_COSTS, LEVEL_MULTIPLIERS } from './buildings.js';
 import { processTurn } from './turn.js';
 
 function init() {
@@ -44,6 +44,9 @@ function init() {
     // Building meshes tracked by hex key
     const buildingMeshes = new Map();
 
+    // Resource gathering particles
+    const gatherParticles = [];
+
     // Game state — initialized after race selection
     let gameState = null;
 
@@ -54,6 +57,10 @@ function init() {
     const turnNumberEl = document.getElementById('turn-number');
     const endTurnBtn = document.getElementById('end-turn-btn');
     const buildMenuEl = document.getElementById('build-menu');
+    const popBarEl = document.getElementById('pop-bar');
+    const minimapCanvas = document.getElementById('minimap-canvas');
+    const saveBtn = document.getElementById('save-btn');
+    const loadBtn = document.getElementById('load-btn');
 
     // ── Race Selection ──
     document.querySelectorAll('.race-card').forEach(function (card) {
@@ -63,39 +70,99 @@ function init() {
         });
     });
 
+    // Continue button for saved games
+    var continueBtn = document.getElementById('continue-btn');
+    if (continueBtn) {
+        if (hasSavedGame()) {
+            continueBtn.classList.add('visible');
+            continueBtn.addEventListener('click', function () {
+                var saved = loadGame();
+                if (saved) {
+                    restoreGame(saved);
+                }
+            });
+        }
+    }
+
     function startGame(race) {
         gameState = createGameState(race);
 
         // Place a free Town Center on a valid hex near the center
-        const centerQ = Math.floor(gridSize / 2);
-        const centerR = Math.floor(gridSize / 2);
-        const tcHex = findValidHex(centerQ, centerR, 'town_center');
+        var centerQ = Math.floor(gridSize / 2);
+        var centerR = Math.floor(gridSize / 2);
+        var tcHex = findValidHex(centerQ, centerR, 'town_center');
         if (tcHex) {
             placeBuilding('town_center', tcHex.q, tcHex.r);
+            // Auto-assign 2 workers to Town Center
+            var tcBuilding = gameState.buildings[gameState.buildings.length - 1];
+            tcBuilding.workers = 2;
         }
 
-        // Hide race selection, show HUD
+        recalcPopulationCap(gameState);
+        showHUD();
+    }
+
+    function restoreGame(state) {
+        gameState = state;
+
+        // Ensure new fields exist for older saves
+        if (!gameState.population) gameState.population = { current: 5, cap: 5 };
+        if (!gameState.hexImprovements) gameState.hexImprovements = [];
+
+        // Rebuild building meshes from state
+        for (var i = 0; i < gameState.buildings.length; i++) {
+            var b = gameState.buildings[i];
+            if (!b.level) b.level = 1;
+            if (b.workers === undefined) b.workers = 0;
+            var key = b.q + ',' + b.r;
+            var hex = hexData.get(key);
+            if (hex) {
+                hex.building = { type: b.type, turnsRemaining: b.turnsRemaining, level: b.level };
+            }
+            var mesh = createBuildingMesh(b.type, b.q, b.r, b.turnsRemaining, b.level);
+            scene.add(mesh);
+            buildingMeshes.set(key, mesh);
+        }
+
+        // Rebuild hex improvements
+        for (var j = 0; j < gameState.hexImprovements.length; j++) {
+            var imp = gameState.hexImprovements[j];
+            var impKey = imp.q + ',' + imp.r;
+            var impHex = hexData.get(impKey);
+            if (impHex) {
+                impHex.improvement = { turnsRemaining: imp.turnsRemaining, bonus: imp.bonus };
+            }
+        }
+
+        recalcPopulationCap(gameState);
+        showHUD();
+    }
+
+    function showHUD() {
         raceSelectEl.classList.add('hidden');
         resourceBarEl.classList.add('visible');
         turnCounterEl.classList.add('visible');
         endTurnBtn.classList.add('visible');
+        popBarEl.classList.add('visible');
+        document.getElementById('save-load-bar').classList.add('visible');
 
         updateResourceBar();
         updateTurnCounter();
+        updatePopBar();
+        drawMinimap();
     }
 
     // Find a valid hex near (cq, cr) for a building type
     function findValidHex(cq, cr, buildingType) {
-        // Spiral outward from center
-        for (let radius = 0; radius < gridSize; radius++) {
-            for (let dq = -radius; dq <= radius; dq++) {
-                for (let dr = -radius; dr <= radius; dr++) {
-                    const q = cq + dq;
-                    const r = cr + dr;
-                    const key = `${q},${r}`;
-                    const hex = hexData.get(key);
+        for (var radius = 0; radius < gridSize; radius++) {
+            for (var dq = -radius; dq <= radius; dq++) {
+                for (var dr = -radius; dr <= radius; dr++) {
+                    var q = cq + dq;
+                    var r = cr + dr;
+                    var key = q + ',' + r;
+                    var hex = hexData.get(key);
                     if (!hex) continue;
-                    const check = canPlaceBuilding(buildingType, hex, gameState.resources);
+                    var check = canPlaceBuilding(buildingType, hex, gameState.resources);
                     if (check.ok) return hex;
                 }
             }
@@ -105,31 +172,61 @@ function init() {
 
     // ── Building Placement ──
     function placeBuilding(buildingType, q, r) {
-        const def = BUILDING_TYPES[buildingType];
-        const key = `${q},${r}`;
-        const hex = hexData.get(key);
+        var def = BUILDING_TYPES[buildingType];
+        var key = q + ',' + r;
+        var hex = hexData.get(key);
 
         // Deduct cost
         gameState.resources = deductCost(buildingType, gameState.resources);
 
         // Add to state
         addBuilding(gameState, buildingType, q, r, def.turnsToBuild);
-        hex.building = { type: buildingType, turnsRemaining: def.turnsToBuild };
+        hex.building = { type: buildingType, turnsRemaining: def.turnsToBuild, level: 1 };
 
         // Create 3D mesh
-        const mesh = createBuildingMesh(buildingType, q, r, def.turnsToBuild);
+        var mesh = createBuildingMesh(buildingType, q, r, def.turnsToBuild, 1);
         scene.add(mesh);
         buildingMeshes.set(key, mesh);
 
         updateResourceBar();
+        updatePopBar();
+        drawMinimap();
+    }
+
+    // ── Building Upgrade ──
+    function upgradeBuilding(buildingState) {
+        var nextLevel = buildingState.level + 1;
+        gameState.resources = deductUpgradeCost(nextLevel, gameState.resources);
+        buildingState.level = nextLevel;
+
+        var key = buildingState.q + ',' + buildingState.r;
+        var hex = hexData.get(key);
+        if (hex && hex.building) {
+            hex.building.level = nextLevel;
+        }
+
+        // Replace mesh
+        var oldMesh = buildingMeshes.get(key);
+        if (oldMesh) {
+            scene.remove(oldMesh);
+            oldMesh.geometry.dispose();
+            oldMesh.material.dispose();
+        }
+        var newMesh = createBuildingMesh(buildingState.type, buildingState.q, buildingState.r, 0, nextLevel);
+        scene.add(newMesh);
+        buildingMeshes.set(key, newMesh);
+
+        recalcPopulationCap(gameState);
+        updateResourceBar();
+        updatePopBar();
     }
 
     // ── HUD Updates ──
     function updateResourceBar() {
         if (!gameState) return;
         resourceBarEl.innerHTML = RESOURCE_TYPES.map(function (type) {
-            const info = RESOURCE_INFO[type];
-            const amount = gameState.resources[type] || 0;
+            var info = RESOURCE_INFO[type];
+            var amount = gameState.resources[type] || 0;
             return '<div class="resource-item">' +
                 '<div class="resource-icon" style="background:' + info.color + '">' + info.icon + '</div>' +
                 '<span class="resource-amount">' + amount + '</span>' +
@@ -142,52 +239,161 @@ function init() {
         turnNumberEl.textContent = gameState.turn;
     }
 
+    function updatePopBar() {
+        if (!gameState) return;
+        var assigned = getAssignedWorkers(gameState);
+        var avail = getAvailableWorkers(gameState);
+        popBarEl.innerHTML =
+            '<span class="pop-label">Pop</span>' +
+            '<span class="pop-number">' + gameState.population.current + '/' + gameState.population.cap + '</span>' +
+            '<span class="pop-sep">|</span>' +
+            '<span class="pop-label">Workers</span>' +
+            '<span class="pop-number">' + assigned + ' assigned, ' + avail + ' free</span>';
+    }
+
     // ── Build Menu ──
     function showBuildMenu(hexKey) {
         if (!gameState) return;
-        const hex = hexData.get(hexKey);
+        var hex = hexData.get(hexKey);
         if (!hex) {
             buildMenuEl.classList.remove('visible');
             return;
         }
 
-        // If hex has a building, show its info
+        // If hex has a building, show its info + workers + upgrade
         if (hex.building) {
-            const bDef = BUILDING_TYPES[hex.building.type];
-            let html = '<div class="build-menu-title">' + bDef.name + '</div>';
+            var bType = hex.building.type;
+            var bDef = BUILDING_TYPES[bType];
+            // Find building in state
+            var buildingState = null;
+            for (var i = 0; i < gameState.buildings.length; i++) {
+                var b = gameState.buildings[i];
+                if (b.q === hex.q && b.r === hex.r) {
+                    buildingState = b;
+                    break;
+                }
+            }
+
+            var html = '<div class="build-menu-title">' + bDef.name;
+            var level = buildingState ? buildingState.level || 1 : 1;
+            if (level > 1) html += ' Lv.' + level;
+            html += '</div>';
+
             if (hex.building.turnsRemaining > 0) {
                 html += '<div class="build-option-info">Under construction: ' + hex.building.turnsRemaining + ' turn' + (hex.building.turnsRemaining !== 1 ? 's' : '') + ' left</div>';
             } else {
-                const producing = Object.entries(bDef.resourcesPerTurn)
+                // Production info (scaled by level)
+                var levelMul = LEVEL_MULTIPLIERS[level] || 1;
+                var producing = Object.entries(bDef.resourcesPerTurn)
                     .filter(function (e) { return e[1] > 0; })
-                    .map(function (e) { return '+' + e[1] + ' ' + RESOURCE_INFO[e[0]].label; })
+                    .map(function (e) { return '+' + Math.floor(e[1] * levelMul) + ' ' + RESOURCE_INFO[e[0]].label; })
                     .join(', ');
                 if (producing) {
                     html += '<div class="build-option-info">Produces: ' + producing + '/turn</div>';
                 }
+
+                // Terrain bonus
+                var tBonus = TERRAIN_BONUSES[hex.terrain];
+                if (tBonus) {
+                    var bonusParts = [];
+                    for (var res in tBonus) {
+                        if (tBonus[res] > 0) bonusParts.push('+' + tBonus[res] + ' ' + RESOURCE_INFO[res].label);
+                    }
+                    if (bonusParts.length > 0) {
+                        html += '<div class="build-option-info terrain-bonus">Terrain: ' + bonusParts.join(', ') + '</div>';
+                    }
+                }
+
+                // Worker slots
+                if (buildingState && bDef.workerSlots > 0) {
+                    var workers = buildingState.workers || 0;
+                    var maxW = bDef.workerSlots;
+                    var avail = getAvailableWorkers(gameState);
+                    html += '<div class="worker-panel">';
+                    html += '<span class="worker-label">Workers: ' + workers + '/' + maxW + '</span>';
+                    if (workers < maxW && avail > 0) {
+                        html += ' <button class="worker-btn" data-action="add">+</button>';
+                    }
+                    if (workers > 0) {
+                        html += ' <button class="worker-btn" data-action="remove">-</button>';
+                    }
+                    if (workers === 0 && maxW > 0) {
+                        html += ' <span class="worker-warn">No workers — idle</span>';
+                    }
+                    html += '</div>';
+                }
+
+                // Upgrade button
+                if (buildingState && level < 3) {
+                    var upCheck = canUpgradeBuilding(buildingState, gameState.resources);
+                    var nextLevel = level + 1;
+                    var upCost = UPGRADE_COSTS[nextLevel];
+                    var costParts = [];
+                    for (var r2 in upCost) {
+                        if (upCost[r2] > 0) {
+                            var has = (gameState.resources[r2] || 0) >= upCost[r2];
+                            costParts.push('<span class="' + (has ? '' : 'cost-short') + '">' + RESOURCE_INFO[r2].icon + upCost[r2] + '</span>');
+                        }
+                    }
+                    html += '<button class="build-option upgrade-btn"' + (upCheck.ok ? '' : ' disabled') + '>' +
+                        '<div class="build-option-name">Upgrade to Lv.' + nextLevel + '</div>' +
+                        '<div class="build-option-cost">' + costParts.join(' ') + '</div>' +
+                        '</button>';
+                }
             }
+
             buildMenuEl.innerHTML = html;
             buildMenuEl.classList.add('visible');
+
+            // Bind worker buttons
+            buildMenuEl.querySelectorAll('.worker-btn').forEach(function (btn) {
+                btn.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    if (!buildingState) return;
+                    var action = this.getAttribute('data-action');
+                    if (action === 'add' && buildingState.workers < bDef.workerSlots && getAvailableWorkers(gameState) > 0) {
+                        buildingState.workers++;
+                    } else if (action === 'remove' && buildingState.workers > 0) {
+                        buildingState.workers--;
+                    }
+                    updatePopBar();
+                    showBuildMenu(hexKey); // Refresh panel
+                });
+            });
+
+            // Bind upgrade button
+            var upgradeBtn = buildMenuEl.querySelector('.upgrade-btn:not(:disabled)');
+            if (upgradeBtn) {
+                upgradeBtn.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    upgradeBuilding(buildingState);
+                    showBuildMenu(hexKey);
+                });
+            }
+
             return;
         }
 
-        let html = '<div class="build-menu-title">Build</div>';
-        for (const [typeKey, def] of Object.entries(BUILDING_TYPES)) {
+        // No building — show build options and hex improve option
+        var html = '<div class="build-menu-title">Build</div>';
+        for (var typeKey in BUILDING_TYPES) {
             if (typeKey === 'town_center') continue; // Can't manually build
-            const check = canPlaceBuilding(typeKey, hex, gameState.resources);
+            var def = BUILDING_TYPES[typeKey];
+            var check = canPlaceBuilding(typeKey, hex, gameState.resources);
 
-            const costParts = [];
-            for (const [res, amt] of Object.entries(def.cost)) {
+            var costParts = [];
+            for (var res in def.cost) {
+                var amt = def.cost[res];
                 if (amt > 0) {
-                    const hasEnough = (gameState.resources[res] || 0) >= amt;
-                    const cls = hasEnough ? '' : ' cost-short';
+                    var hasEnough = (gameState.resources[res] || 0) >= amt;
+                    var cls = hasEnough ? '' : ' cost-short';
                     costParts.push('<span class="' + cls + '">' + RESOURCE_INFO[res].icon + amt + '</span>');
                 }
             }
 
-            const costStr = costParts.join(' ');
-            const turnsStr = def.turnsToBuild > 0 ? def.turnsToBuild + ' turns' : 'Instant';
-            const reason = check.ok ? '' : ' title="' + check.reason + '"';
+            var costStr = costParts.join(' ');
+            var turnsStr = def.turnsToBuild > 0 ? def.turnsToBuild + ' turns' : 'Instant';
+            var reason = check.ok ? '' : ' title="' + check.reason + '"';
 
             html += '<button class="build-option"' +
                 (check.ok ? '' : ' disabled') +
@@ -199,62 +405,282 @@ function init() {
                 '</button>';
         }
 
+        // Hex improvement option
+        if (!hex.improvement && hex.terrain !== 'water') {
+            var impBonus = TERRAIN_BONUSES[hex.terrain];
+            var hasBonus = false;
+            for (var r3 in impBonus) {
+                if (impBonus[r3] > 0) { hasBonus = true; break; }
+            }
+            if (hasBonus && getAvailableWorkers(gameState) > 0) {
+                var bonusDesc = [];
+                for (var r4 in impBonus) {
+                    if (impBonus[r4] > 0) bonusDesc.push('+' + impBonus[r4] + ' ' + RESOURCE_INFO[r4].label);
+                }
+                html += '<button class="build-option improve-hex-btn">' +
+                    '<div class="build-option-name">Improve Hex</div>' +
+                    '<div class="build-option-cost">1 worker, 3 turns</div>' +
+                    '<div class="build-option-info">' + bonusDesc.join(', ') + '/turn</div>' +
+                    '</button>';
+            }
+        } else if (hex.improvement) {
+            if (hex.improvement.turnsRemaining > 0) {
+                html += '<div class="build-option-info">Improving: ' + hex.improvement.turnsRemaining + ' turns left</div>';
+            } else {
+                html += '<div class="build-option-info">Hex improved</div>';
+            }
+        }
+
         buildMenuEl.innerHTML = html;
         buildMenuEl.classList.add('visible');
 
-        // Bind click handlers
-        buildMenuEl.querySelectorAll('.build-option:not(:disabled)').forEach(function (btn) {
+        // Bind build click handlers
+        buildMenuEl.querySelectorAll('.build-option[data-building]:not(:disabled)').forEach(function (btn) {
             btn.addEventListener('click', function (e) {
                 e.stopPropagation();
-                const buildingType = this.getAttribute('data-building');
+                var buildingType = this.getAttribute('data-building');
                 placeBuilding(buildingType, hex.q, hex.r);
                 buildMenuEl.classList.remove('visible');
-                // Re-trigger hex info update
                 if (inputApi) inputApi.refreshSelection();
             });
         });
+
+        // Bind hex improvement
+        var improveBtn = buildMenuEl.querySelector('.improve-hex-btn');
+        if (improveBtn) {
+            improveBtn.addEventListener('click', function (e) {
+                e.stopPropagation();
+                var bonus = {};
+                var tb = TERRAIN_BONUSES[hex.terrain];
+                for (var r5 in tb) {
+                    if (tb[r5] > 0) bonus[r5] = tb[r5];
+                }
+                startHexImprovement(gameState, hex.q, hex.r, bonus);
+                hex.improvement = { turnsRemaining: 3, bonus: bonus };
+                showBuildMenu(hexKey);
+                drawMinimap();
+            });
+        }
     }
 
     function hideBuildMenu() {
         buildMenuEl.classList.remove('visible');
     }
 
+    // ── Resource Gathering Visualization ──
+    function spawnGatherParticles(gathered) {
+        // For each building that produced, spawn particles rising from it
+        for (var i = 0; i < gameState.buildings.length; i++) {
+            var b = gameState.buildings[i];
+            if (b.turnsRemaining > 0) continue;
+            var def = BUILDING_TYPES[b.type];
+            var hasProduction = false;
+            for (var res in def.resourcesPerTurn) {
+                if (def.resourcesPerTurn[res] > 0 && b.workers > 0) { hasProduction = true; break; }
+            }
+            if (!hasProduction && def.workerSlots > 0) continue;
+            if (!hasProduction) continue;
+
+            var pos = axialToWorld(b.q, b.r);
+            // Determine dominant resource color
+            var dominantRes = null;
+            var maxAmt = 0;
+            for (var res2 in def.resourcesPerTurn) {
+                if (def.resourcesPerTurn[res2] > maxAmt) {
+                    maxAmt = def.resourcesPerTurn[res2];
+                    dominantRes = res2;
+                }
+            }
+            var pColor = dominantRes ? RESOURCE_INFO[dominantRes].color : '#ffffff';
+
+            // Create a small sprite/indicator
+            var spriteMat = new THREE.SpriteMaterial({
+                color: new THREE.Color(pColor),
+                transparent: true,
+                opacity: 0.9,
+            });
+            var sprite = new THREE.Sprite(spriteMat);
+            sprite.scale.set(0.2, 0.2, 0.2);
+            var yStart = 0.3 + (def.scale.y * (LEVEL_MULTIPLIERS[b.level || 1] || 1));
+            sprite.position.set(pos.x, yStart, pos.z);
+            scene.add(sprite);
+
+            gatherParticles.push({
+                sprite: sprite,
+                startY: yStart,
+                life: 0,
+                maxLife: 60, // frames
+            });
+        }
+    }
+
+    function updateParticles() {
+        for (var i = gatherParticles.length - 1; i >= 0; i--) {
+            var p = gatherParticles[i];
+            p.life++;
+            var t = p.life / p.maxLife;
+            p.sprite.position.y = p.startY + t * 1.5;
+            p.sprite.material.opacity = 0.9 * (1 - t);
+            if (p.life >= p.maxLife) {
+                scene.remove(p.sprite);
+                p.sprite.material.dispose();
+                gatherParticles.splice(i, 1);
+            }
+        }
+    }
+
+    // ── Minimap ──
+    function drawMinimap() {
+        if (!minimapCanvas) return;
+        var ctx = minimapCanvas.getContext('2d');
+        var w = minimapCanvas.width;
+        var h = minimapCanvas.height;
+        ctx.clearRect(0, 0, w, h);
+
+        var cellW = w / gridSize;
+        var cellH = h / gridSize;
+
+        var terrainColors = {
+            plains: '#4ade80',
+            forest: '#166534',
+            mountain: '#6b7280',
+            water: '#3b82f6',
+            desert: '#d4a574',
+        };
+
+        hexData.forEach(function (hex, key) {
+            var x = hex.q * cellW;
+            var y = hex.r * cellH;
+
+            // Terrain base color
+            ctx.fillStyle = terrainColors[hex.terrain] || '#333';
+            ctx.fillRect(x, y, cellW, cellH);
+
+            // Building indicator
+            if (hex.building) {
+                ctx.fillStyle = '#fbbf24';
+                var pad = cellW * 0.2;
+                ctx.fillRect(x + pad, y + pad, cellW - pad * 2, cellH - pad * 2);
+            }
+
+            // Improvement indicator
+            if (hex.improvement && hex.improvement.turnsRemaining <= 0) {
+                ctx.fillStyle = 'rgba(255,255,255,0.3)';
+                ctx.fillRect(x, y, cellW, cellH);
+            }
+        });
+
+        // Settlement extent border
+        if (gameState && gameState.buildings.length > 0) {
+            ctx.strokeStyle = '#fbbf24';
+            ctx.lineWidth = 1;
+            var minQ = gridSize, maxQ = 0, minR = gridSize, maxR = 0;
+            for (var i = 0; i < gameState.buildings.length; i++) {
+                var b = gameState.buildings[i];
+                if (b.q < minQ) minQ = b.q;
+                if (b.q > maxQ) maxQ = b.q;
+                if (b.r < minR) minR = b.r;
+                if (b.r > maxR) maxR = b.r;
+            }
+            ctx.strokeRect(
+                minQ * cellW - 1,
+                minR * cellH - 1,
+                (maxQ - minQ + 1) * cellW + 2,
+                (maxR - minR + 1) * cellH + 2
+            );
+        }
+    }
+
+    // ── Save / Load ──
+    saveBtn.addEventListener('click', function () {
+        if (!gameState) return;
+        if (saveGame(gameState)) {
+            saveBtn.textContent = 'Saved!';
+            setTimeout(function () { saveBtn.textContent = 'Save'; }, 1000);
+        }
+    });
+
+    loadBtn.addEventListener('click', function () {
+        var saved = loadGame();
+        if (saved) {
+            // Clear existing scene buildings
+            buildingMeshes.forEach(function (mesh) {
+                scene.remove(mesh);
+                mesh.geometry.dispose();
+                mesh.material.dispose();
+            });
+            buildingMeshes.clear();
+
+            // Clear hex data buildings/improvements
+            hexData.forEach(function (hex) {
+                hex.building = null;
+                hex.improvement = null;
+            });
+
+            restoreGame(saved);
+            loadBtn.textContent = 'Loaded!';
+            setTimeout(function () { loadBtn.textContent = 'Load'; }, 1000);
+
+            if (inputApi && inputApi.getSelectedKey()) {
+                showBuildMenu(inputApi.getSelectedKey());
+            }
+        }
+    });
+
     // ── End Turn ──
     endTurnBtn.addEventListener('click', function () {
         if (!gameState) return;
 
-        processTurn(gameState, function onComplete(building) {
+        var gathered = processTurn(gameState, function onComplete(building) {
             // Building finished construction
-            const key = building.q + ',' + building.r;
-            const hex = hexData.get(key);
+            var key = building.q + ',' + building.r;
+            var hex = hexData.get(key);
             if (hex && hex.building) {
                 hex.building.turnsRemaining = 0;
             }
-        });
+        }, hexData);
 
         // Update building meshes for construction progress
-        for (const building of gameState.buildings) {
-            const key = building.q + ',' + building.r;
-            const mesh = buildingMeshes.get(key);
+        for (var i = 0; i < gameState.buildings.length; i++) {
+            var building = gameState.buildings[i];
+            var key = building.q + ',' + building.r;
+            var mesh = buildingMeshes.get(key);
             if (mesh) {
                 // Remove old mesh, create updated one
                 scene.remove(mesh);
                 mesh.geometry.dispose();
                 mesh.material.dispose();
-                const newMesh = createBuildingMesh(building.type, building.q, building.r, building.turnsRemaining);
+                var newMesh = createBuildingMesh(building.type, building.q, building.r, building.turnsRemaining, building.level || 1);
                 scene.add(newMesh);
                 buildingMeshes.set(key, newMesh);
             }
 
             // Sync hex data
-            const hex = hexData.get(key);
+            var hex = hexData.get(key);
             if (hex && hex.building) {
                 hex.building.turnsRemaining = building.turnsRemaining;
             }
         }
 
+        // Update hex improvements in hexData
+        if (gameState.hexImprovements) {
+            for (var j = 0; j < gameState.hexImprovements.length; j++) {
+                var imp = gameState.hexImprovements[j];
+                var impKey = imp.q + ',' + imp.r;
+                var impHex = hexData.get(impKey);
+                if (impHex && impHex.improvement) {
+                    impHex.improvement.turnsRemaining = imp.turnsRemaining;
+                }
+            }
+        }
+
+        // Spawn resource gathering particles
+        spawnGatherParticles(gathered);
+
         updateResourceBar();
         updateTurnCounter();
+        updatePopBar();
+        drawMinimap();
 
         // Refresh build menu if open
         if (inputApi && inputApi.getSelectedKey()) {
@@ -263,7 +689,7 @@ function init() {
     });
 
     // Input — connect with build menu callbacks
-    const inputApi = setupInput(camera, hexMeshes, hexData, {
+    var inputApi = setupInput(camera, hexMeshes, hexData, {
         onSelect: function (key) {
             if (key) {
                 showBuildMenu(key);
@@ -286,6 +712,7 @@ function init() {
     function animate() {
         requestAnimationFrame(animate);
         updateKeys();
+        updateParticles();
         controls.update();
         renderer.render(scene, camera);
     }

--- a/game-demo/js/resources.js
+++ b/game-demo/js/resources.js
@@ -1,4 +1,4 @@
-// resources.js — Resource definitions, gathering rates, and race bonuses
+// resources.js — Resource definitions, gathering rates, race bonuses, terrain bonuses
 
 export const RESOURCE_TYPES = ['food', 'wood', 'stone', 'gold', 'mana'];
 
@@ -25,12 +25,23 @@ export const RACE_BONUSES = {
     orc:   { food: 1, wood: 1,   stone: 1.5, gold: 1,   mana: 1 },
 };
 
+// Terrain bonuses — passive resource bonus per turn for buildings on matching terrain
+export const TERRAIN_BONUSES = {
+    plains:   { food: 1, wood: 0, stone: 0, gold: 0, mana: 0 },
+    forest:   { food: 0, wood: 1, stone: 0, gold: 0, mana: 0 },
+    mountain: { food: 0, wood: 0, stone: 1, gold: 0, mana: 0 },
+    desert:   { food: 0, wood: 0, stone: 0, gold: 1, mana: 0 },
+    water:    { food: 0, wood: 0, stone: 0, gold: 0, mana: 0 },
+};
+
 // Calculate gathered resources for a building given race bonuses
-export function gatherResources(buildingDef, race) {
+// workerRatio: fraction of worker slots filled (0 to 1), defaults to 1 for backward compat
+export function gatherResources(buildingDef, race, workerRatio) {
+    if (workerRatio === undefined) workerRatio = 1;
     const bonuses = RACE_BONUSES[race];
     const gathered = {};
     for (const [resource, amount] of Object.entries(buildingDef.resourcesPerTurn)) {
-        gathered[resource] = Math.floor(amount * (bonuses[resource] || 1));
+        gathered[resource] = Math.floor(amount * (bonuses[resource] || 1) * workerRatio);
     }
     return gathered;
 }


### PR DESCRIPTION
Closes #13

## Acceptance Criteria

- [x] Population system — Town Center provides starting pop, Farms increase cap
- [x] Workers — assign population to buildings to activate them
  - Unassigned workers produce nothing
  - Building panel shows worker slots
- [x] Resource gathering visualization — simple particle or indicator showing resources flowing
- [x] Building upgrades — level 1/2/3 for core buildings (visual change: taller/wider primitive)
- [x] Terrain bonuses — forests give +wood, mountains give +stone, plains give +food
- [x] Hex improvement — workers can "improve" a hex (takes N turns, adds resource bonus)
- [x] Mini-map or overview indicator showing settlement extent
- [x] Save/Load game state to localStorage

## Changes

### Population & Workers
- Town Center provides 5 starting population; Farms add +3 pop cap per level
- Workers can be assigned/unassigned to buildings via +/- buttons in the building panel
- Buildings with no workers assigned are idle and produce nothing
- Population grows +1/turn (costs 5 food) when below cap

### Building Upgrades
- All buildings can be upgraded to Lv.2 and Lv.3
- Each level increases resource output (1.3x at Lv.2, 1.6x at Lv.3)
- Visual change: buildings get taller, wider, and slightly brighter at higher levels
- Upgrade costs scale with level

### Terrain Bonuses
- Plains: +1 food/turn for buildings on this terrain
- Forest: +1 wood/turn
- Mountain: +1 stone/turn
- Desert: +1 gold/turn
- Shown in building info panel as "Terrain: +1 Food"

### Hex Improvements
- Empty hexes can be "improved" (3 turns, requires 1 available worker)
- Completed improvements provide passive terrain bonus each turn
- Shown on minimap and hex info overlay

### Resource Gathering Visualization
- Colored sprite particles rise from producing buildings each turn
- Color matches dominant resource type (green for food, gold for gold, etc.)
- Particles fade out over 60 frames

### Minimap
- 120x120 pixel canvas in bottom-left showing terrain colors
- Buildings shown as gold dots; improved hexes have white overlay
- Settlement extent highlighted with gold border

### Save/Load
- Save/Load buttons in HUD bar
- Saves full game state to localStorage
- "Continue Saved Game" button on race selection screen when save exists
- Handles loading older saves gracefully (adds missing new fields)

## Files Changed
- `game-demo/index.html` — New UI elements (pop bar, minimap, save/load, continue btn, worker/upgrade styles)
- `game-demo/js/game-state.js` — Population, hex improvements, save/load localStorage
- `game-demo/js/resources.js` — Terrain bonuses, worker ratio in gathering
- `game-demo/js/buildings.js` — Worker slots, population cap, upgrades, level multipliers
- `game-demo/js/turn.js` — Worker-scaled gathering, terrain bonuses, hex improvements, pop growth
- `game-demo/js/main.js` — All new systems integrated (workers, upgrades, particles, minimap, save/load)
- `game-demo/js/input.js` — Updated overlay for levels/improvements, new UI click guards