### PR TITLE
Game Demo: Phase 3 — Race differentiation & tech tree

### DIFF
--- a/game-demo/index.html
+++ b/game-demo/index.html
@@ -216,6 +216,41 @@
             margin: 0 0.2rem;
         }
 
+        /* Research status bar */
+        #research-status {
+            position: fixed;
+            top: 5.5rem;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 10;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 0.35rem 1rem;
+            display: none;
+            align-items: center;
+            gap: 0.3rem;
+            font-size: 0.8rem;
+        }
+
+        #research-status.visible {
+            display: flex;
+        }
+
+        .research-label {
+            color: var(--muted);
+        }
+
+        .research-name {
+            color: var(--accent);
+            font-weight: 600;
+        }
+
+        .research-turns {
+            color: var(--muted);
+            font-size: 0.75rem;
+        }
+
         /* Turn counter */
         #turn-counter {
             position: fixed;
@@ -304,6 +339,33 @@
 
         #save-load-bar button:hover {
             border-color: var(--accent);
+        }
+
+        /* Tech tree button */
+        #tech-tree-btn {
+            position: fixed;
+            bottom: 1rem;
+            right: 18rem;
+            z-index: 10;
+            background: var(--surface);
+            border: 1px solid var(--accent-dim);
+            border-radius: 6px;
+            padding: 0.4rem 0.8rem;
+            font-size: 0.8rem;
+            font-family: inherit;
+            color: var(--accent);
+            cursor: pointer;
+            display: none;
+            transition: border-color 0.2s, transform 0.1s;
+        }
+
+        #tech-tree-btn.visible {
+            display: block;
+        }
+
+        #tech-tree-btn:hover {
+            border-color: var(--accent);
+            transform: translateY(-1px);
         }
 
         /* Build menu panel */
@@ -520,6 +582,13 @@
             color: var(--accent-dim);
         }
 
+        .race-buildings {
+            font-size: 0.7rem;
+            color: var(--muted);
+            margin-top: 0.4rem;
+            line-height: 1.4;
+        }
+
         /* Continue button */
         #continue-btn {
             display: none;
@@ -545,6 +614,168 @@
             transform: translateY(-2px);
         }
 
+        /* ── Tech Tree Panel ── */
+        #tech-tree-panel {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 50;
+            background: rgba(10, 10, 15, 0.92);
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            padding: 2rem;
+            overflow-y: auto;
+        }
+
+        #tech-tree-panel.visible {
+            display: flex;
+        }
+
+        .tech-tree-header {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+            width: 100%;
+            max-width: 900px;
+        }
+
+        .tech-tree-title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--accent);
+            flex: 1;
+        }
+
+        #tech-tree-close {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text);
+            font-size: 1rem;
+            padding: 0.4rem 0.8rem;
+            cursor: pointer;
+            font-family: inherit;
+            transition: border-color 0.2s;
+        }
+
+        #tech-tree-close:hover {
+            border-color: var(--accent);
+        }
+
+        #tech-tree-content {
+            display: flex;
+            gap: 1.5rem;
+            width: 100%;
+            max-width: 900px;
+            align-items: flex-start;
+        }
+
+        .tech-branch {
+            flex: 1;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 1rem;
+            min-width: 0;
+        }
+
+        .tech-branch-title {
+            font-size: 0.9rem;
+            font-weight: 700;
+            color: var(--accent);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.8rem;
+            text-align: center;
+        }
+
+        .tech-node {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 0.6rem 0.8rem;
+            margin-bottom: 0.6rem;
+            transition: border-color 0.2s;
+        }
+
+        .tech-node.tech-completed {
+            border-color: #10b981;
+        }
+
+        .tech-node.tech-researching {
+            border-color: var(--accent);
+        }
+
+        .tech-node.tech-available {
+            border-color: var(--accent-dim);
+        }
+
+        .tech-node.tech-locked {
+            opacity: 0.45;
+        }
+
+        .tech-node-name {
+            font-weight: 600;
+            font-size: 0.85rem;
+            margin-bottom: 0.2rem;
+        }
+
+        .tech-prereqs {
+            font-size: 0.65rem;
+            color: var(--muted);
+            margin-bottom: 0.15rem;
+        }
+
+        .tech-cost {
+            font-size: 0.7rem;
+            color: var(--muted);
+            margin-bottom: 0.15rem;
+        }
+
+        .tech-desc {
+            font-size: 0.7rem;
+            color: var(--accent-dim);
+            margin-bottom: 0.3rem;
+        }
+
+        .tech-progress {
+            font-size: 0.7rem;
+            color: var(--accent);
+            font-weight: 600;
+        }
+
+        .tech-done {
+            font-size: 0.7rem;
+            color: #10b981;
+            font-weight: 600;
+        }
+
+        .tech-research-btn {
+            background: var(--accent-dim);
+            border: 1px solid var(--accent);
+            border-radius: 4px;
+            color: var(--bg);
+            font-size: 0.75rem;
+            font-weight: 600;
+            padding: 0.25rem 0.6rem;
+            cursor: pointer;
+            font-family: inherit;
+            transition: background 0.2s;
+        }
+
+        .tech-research-btn:hover:not(:disabled) {
+            background: var(--accent);
+        }
+
+        .tech-research-btn:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
         @media (max-width: 600px) {
             .race-options {
                 flex-direction: column;
@@ -560,6 +791,14 @@
             #minimap {
                 display: none;
             }
+
+            #tech-tree-content {
+                flex-direction: column;
+            }
+
+            #tech-tree-panel {
+                padding: 1rem;
+            }
         }
     </style>
 </head>
@@ -569,22 +808,25 @@
     <!-- Race selection overlay -->
     <div id="race-select">
         <div class="race-select-title">Choose Your Race</div>
-        <div class="race-select-subtitle">Each race has unique resource bonuses</div>
+        <div class="race-select-subtitle">Each race has unique buildings, tech trees & resource bonuses</div>
         <div class="race-options">
             <button class="race-card" data-race="human">
                 <div class="race-icon">&#9812;</div>
                 <div class="race-name">Human</div>
-                <div class="race-bonus">+50% Gold</div>
+                <div class="race-bonus">+50% Gold, +10% Food</div>
+                <div class="race-buildings">Castle, Market, Chapel</div>
             </button>
             <button class="race-card" data-race="elf">
                 <div class="race-icon">&#9816;</div>
                 <div class="race-name">Elf</div>
-                <div class="race-bonus">+50% Wood, +30% Mana</div>
+                <div class="race-bonus">+50% Wood, +40% Mana</div>
+                <div class="race-buildings">Tree of Life, Moonwell, Ancient Archive</div>
             </button>
             <button class="race-card" data-race="orc">
                 <div class="race-icon">&#9820;</div>
                 <div class="race-name">Orc</div>
-                <div class="race-bonus">+50% Stone</div>
+                <div class="race-bonus">+50% Stone, +20% Food</div>
+                <div class="race-buildings">War Pit, Blood Forge, Totem</div>
             </button>
         </div>
         <button id="continue-btn">Continue Saved Game</button>
@@ -602,6 +844,9 @@
     <!-- Population bar -->
     <div id="pop-bar"></div>
 
+    <!-- Research status -->
+    <div id="research-status"></div>
+
     <!-- Turn counter -->
     <div id="turn-counter">
         <span class="turn-label">Turn</span>
@@ -616,6 +861,9 @@
         <button id="save-btn">Save</button>
         <button id="load-btn">Load</button>
     </div>
+
+    <!-- Tech Tree button -->
+    <button id="tech-tree-btn">Tech Tree</button>
 
     <!-- Build menu (shown when hex selected) -->
     <div id="build-menu"></div>
@@ -632,6 +880,15 @@
     <!-- Minimap -->
     <div id="minimap">
         <canvas id="minimap-canvas" width="120" height="120"></canvas>
+    </div>
+
+    <!-- Tech Tree Panel (full-screen overlay) -->
+    <div id="tech-tree-panel">
+        <div class="tech-tree-header">
+            <div class="tech-tree-title">Tech Tree</div>
+            <button id="tech-tree-close">Close</button>
+        </div>
+        <div id="tech-tree-content"></div>
     </div>
 
     <script type="importmap">

--- a/game-demo/js/buildings.js
+++ b/game-demo/js/buildings.js
@@ -1,13 +1,34 @@
 // buildings.js — Building definitions, placement, upgrades, and 3D rendering
 // Buildings render as simple Three.js primitives (boxes, cylinders)
+// Includes race-specific building variants with unique colors and stats
 
 import * as THREE from 'three';
 import { axialToWorld, HEX_SIZE } from './hex-grid.js';
+
+// ── Race Color Palettes ──
+export const RACE_PALETTES = {
+    human: {
+        primary: 0x94a3b8,    // stone gray
+        secondary: 0x60a5fa,  // blue
+        accent: 0xfbbf24,     // gold
+    },
+    elf: {
+        primary: 0x8b6914,    // wood brown
+        secondary: 0x10b981,  // emerald green
+        accent: 0xc0c0c0,     // silver
+    },
+    orc: {
+        primary: 0x3f3f3f,    // dark iron
+        secondary: 0xdc2626,  // red
+        accent: 0xe8dcc8,     // bone white
+    },
+};
 
 // Building type definitions
 // workerSlots: max workers that can be assigned
 // populationCap: added to settlement pop cap when complete
 export const BUILDING_TYPES = {
+    // ── Shared Buildings ──
     town_center: {
         name: 'Town Center',
         cost: { food: 0, wood: 0, stone: 0, gold: 0, mana: 0 },
@@ -19,6 +40,7 @@ export const BUILDING_TYPES = {
         scale: { x: 0.5, y: 0.6, z: 0.5 },
         workerSlots: 2,
         populationCap: 5,
+        races: ['human', 'elf', 'orc'],
     },
     farm: {
         name: 'Farm',
@@ -31,6 +53,7 @@ export const BUILDING_TYPES = {
         scale: { x: 0.6, y: 0.2, z: 0.6 },
         workerSlots: 2,
         populationCap: 3,
+        races: ['human', 'elf', 'orc'],
     },
     lumber_mill: {
         name: 'Lumber Mill',
@@ -43,6 +66,7 @@ export const BUILDING_TYPES = {
         scale: { x: 0.25, y: 0.5, z: 0.25 },
         workerSlots: 2,
         populationCap: 0,
+        races: ['human', 'elf', 'orc'],
     },
     quarry: {
         name: 'Quarry',
@@ -55,6 +79,7 @@ export const BUILDING_TYPES = {
         scale: { x: 0.3, y: 0.5, z: 0.3 },
         workerSlots: 2,
         populationCap: 0,
+        races: ['human', 'elf', 'orc'],
     },
     mine: {
         name: 'Mine',
@@ -67,6 +92,7 @@ export const BUILDING_TYPES = {
         scale: { x: 0.3, y: 0.35, z: 0.3 },
         workerSlots: 2,
         populationCap: 0,
+        races: ['human', 'elf', 'orc'],
     },
     barracks: {
         name: 'Barracks',
@@ -79,6 +105,7 @@ export const BUILDING_TYPES = {
         scale: { x: 0.45, y: 0.4, z: 0.45 },
         workerSlots: 1,
         populationCap: 0,
+        races: ['human', 'elf', 'orc'],
     },
     mage_tower: {
         name: 'Mage Tower',
@@ -91,6 +118,7 @@ export const BUILDING_TYPES = {
         scale: { x: 0.2, y: 0.8, z: 0.2 },
         workerSlots: 1,
         populationCap: 0,
+        races: ['human', 'elf', 'orc'],
     },
     walls: {
         name: 'Walls',
@@ -103,6 +131,172 @@ export const BUILDING_TYPES = {
         scale: { x: 0.7, y: 0.3, z: 0.1 },
         workerSlots: 0,
         populationCap: 0,
+        races: ['human', 'elf', 'orc'],
+    },
+
+    // ── Human-specific Buildings ──
+    market: {
+        name: 'Market',
+        cost: { food: 15, wood: 25, stone: 10, gold: 10, mana: 0 },
+        turnsToBuild: 3,
+        resourcesPerTurn: { food: 0, wood: 0, stone: 0, gold: 6, mana: 0 },
+        requiredTerrain: ['plains', 'desert'],
+        shape: 'box',
+        color: 0x60a5fa,    // human blue
+        scale: { x: 0.5, y: 0.35, z: 0.4 },
+        workerSlots: 2,
+        populationCap: 0,
+        races: ['human'],
+    },
+    castle: {
+        name: 'Castle',
+        cost: { food: 20, wood: 40, stone: 50, gold: 30, mana: 0 },
+        turnsToBuild: 6,
+        resourcesPerTurn: { food: 0, wood: 0, stone: 2, gold: 3, mana: 0 },
+        requiredTerrain: ['plains', 'mountain'],
+        shape: 'box',
+        color: 0x94a3b8,    // stone gray
+        scale: { x: 0.55, y: 0.7, z: 0.55 },
+        workerSlots: 2,
+        populationCap: 5,
+        races: ['human'],
+    },
+    chapel: {
+        name: 'Chapel',
+        cost: { food: 10, wood: 20, stone: 15, gold: 15, mana: 5 },
+        turnsToBuild: 4,
+        resourcesPerTurn: { food: 0, wood: 0, stone: 0, gold: 1, mana: 3 },
+        requiredTerrain: ['plains', 'forest'],
+        shape: 'cone',
+        color: 0xf0f0ff,    // pale white/blue
+        scale: { x: 0.25, y: 0.65, z: 0.25 },
+        workerSlots: 1,
+        populationCap: 0,
+        races: ['human'],
+    },
+    // Human ultimate
+    grand_cathedral: {
+        name: 'Grand Cathedral',
+        cost: { food: 40, wood: 60, stone: 80, gold: 60, mana: 30 },
+        turnsToBuild: 10,
+        resourcesPerTurn: { food: 2, wood: 0, stone: 0, gold: 8, mana: 5 },
+        requiredTerrain: ['plains'],
+        shape: 'cone',
+        color: 0xfbbf24,    // gold
+        scale: { x: 0.4, y: 1.2, z: 0.4 },
+        workerSlots: 3,
+        populationCap: 8,
+        races: ['human'],
+    },
+
+    // ── Elf-specific Buildings ──
+    tree_of_life: {
+        name: 'Tree of Life',
+        cost: { food: 10, wood: 30, stone: 5, gold: 10, mana: 10 },
+        turnsToBuild: 4,
+        resourcesPerTurn: { food: 2, wood: 4, stone: 0, gold: 0, mana: 1 },
+        requiredTerrain: ['forest', 'plains'],
+        shape: 'cone',
+        color: 0x10b981,    // emerald green
+        scale: { x: 0.3, y: 0.7, z: 0.3 },
+        workerSlots: 2,
+        populationCap: 4,
+        races: ['elf'],
+    },
+    moonwell: {
+        name: 'Moonwell',
+        cost: { food: 5, wood: 15, stone: 10, gold: 10, mana: 10 },
+        turnsToBuild: 3,
+        resourcesPerTurn: { food: 0, wood: 0, stone: 0, gold: 0, mana: 5 },
+        requiredTerrain: ['forest', 'plains'],
+        shape: 'cylinder',
+        color: 0xc0c0c0,    // silver
+        scale: { x: 0.3, y: 0.2, z: 0.3 },
+        workerSlots: 1,
+        populationCap: 0,
+        races: ['elf'],
+    },
+    ancient_archive: {
+        name: 'Ancient Archive',
+        cost: { food: 10, wood: 25, stone: 20, gold: 25, mana: 20 },
+        turnsToBuild: 5,
+        resourcesPerTurn: { food: 0, wood: 0, stone: 0, gold: 3, mana: 4 },
+        requiredTerrain: ['forest'],
+        shape: 'cylinder',
+        color: 0xc0c0c0,    // silver
+        scale: { x: 0.3, y: 0.6, z: 0.3 },
+        workerSlots: 2,
+        populationCap: 0,
+        races: ['elf'],
+    },
+    // Elf ultimate
+    world_tree: {
+        name: 'World Tree',
+        cost: { food: 30, wood: 80, stone: 20, gold: 40, mana: 50 },
+        turnsToBuild: 10,
+        resourcesPerTurn: { food: 3, wood: 6, stone: 0, gold: 2, mana: 8 },
+        requiredTerrain: ['forest'],
+        shape: 'cone',
+        color: 0x10b981,    // emerald green
+        scale: { x: 0.45, y: 1.4, z: 0.45 },
+        workerSlots: 3,
+        populationCap: 10,
+        races: ['elf'],
+    },
+
+    // ── Orc-specific Buildings ──
+    war_pit: {
+        name: 'War Pit',
+        cost: { food: 30, wood: 20, stone: 35, gold: 15, mana: 0 },
+        turnsToBuild: 5,
+        resourcesPerTurn: { food: 0, wood: 0, stone: 2, gold: 0, mana: 0 },
+        requiredTerrain: ['plains', 'desert'],
+        shape: 'cylinder',
+        color: 0xdc2626,    // red
+        scale: { x: 0.4, y: 0.3, z: 0.4 },
+        workerSlots: 2,
+        populationCap: 4,
+        races: ['orc'],
+    },
+    blood_forge: {
+        name: 'Blood Forge',
+        cost: { food: 20, wood: 25, stone: 30, gold: 20, mana: 0 },
+        turnsToBuild: 4,
+        resourcesPerTurn: { food: 0, wood: 0, stone: 3, gold: 3, mana: 0 },
+        requiredTerrain: ['mountain', 'desert'],
+        shape: 'box',
+        color: 0x3f3f3f,    // dark iron
+        scale: { x: 0.4, y: 0.45, z: 0.35 },
+        workerSlots: 2,
+        populationCap: 0,
+        races: ['orc'],
+    },
+    totem: {
+        name: 'Totem',
+        cost: { food: 10, wood: 15, stone: 15, gold: 5, mana: 5 },
+        turnsToBuild: 3,
+        resourcesPerTurn: { food: 0, wood: 0, stone: 0, gold: 0, mana: 4 },
+        requiredTerrain: ['plains', 'desert', 'forest'],
+        shape: 'cylinder',
+        color: 0xe8dcc8,    // bone white
+        scale: { x: 0.15, y: 0.7, z: 0.15 },
+        workerSlots: 1,
+        populationCap: 0,
+        races: ['orc'],
+    },
+    // Orc ultimate
+    skull_throne: {
+        name: 'Skull Throne',
+        cost: { food: 50, wood: 30, stone: 70, gold: 40, mana: 20 },
+        turnsToBuild: 10,
+        resourcesPerTurn: { food: 4, wood: 0, stone: 5, gold: 5, mana: 3 },
+        requiredTerrain: ['plains', 'desert'],
+        shape: 'box',
+        color: 0xdc2626,    // red
+        scale: { x: 0.5, y: 1.0, z: 0.5 },
+        workerSlots: 3,
+        populationCap: 8,
+        races: ['orc'],
     },
 };
 
@@ -118,6 +312,42 @@ export const LEVEL_MULTIPLIERS = {
     2: 1.3,
     3: 1.6,
 };
+
+// Get the color for a building based on race palette
+export function getBuildingColor(buildingType, race) {
+    var def = BUILDING_TYPES[buildingType];
+    if (!def) return 0xffffff;
+
+    // Race-specific buildings use their own colors
+    if (def.races && def.races.length === 1) {
+        return def.color;
+    }
+
+    // Shared buildings — tint based on race palette
+    var palette = RACE_PALETTES[race];
+    if (!palette) return def.color;
+
+    // Town center uses race accent color
+    if (buildingType === 'town_center') return palette.accent;
+    // Barracks uses race secondary (military)
+    if (buildingType === 'barracks') return palette.secondary;
+    // Walls use race primary
+    if (buildingType === 'walls') return palette.primary;
+
+    return def.color;
+}
+
+// Get buildings available to a specific race
+export function getBuildingsForRace(race) {
+    var result = {};
+    for (var key in BUILDING_TYPES) {
+        var def = BUILDING_TYPES[key];
+        if (def.races && def.races.includes(race)) {
+            result[key] = def;
+        }
+    }
+    return result;
+}
 
 // Check if a building can be placed on a hex
 export function canPlaceBuilding(buildingType, hexData, resources) {
@@ -185,8 +415,8 @@ export function deductUpgradeCost(level, resources) {
     return newResources;
 }
 
-// Create a 3D mesh for a building
-export function createBuildingMesh(buildingType, q, r, turnsRemaining, level) {
+// Create a 3D mesh for a building (with optional race-based color)
+export function createBuildingMesh(buildingType, q, r, turnsRemaining, level, race) {
     if (level === undefined) level = 1;
     const def = BUILDING_TYPES[buildingType];
     const pos = axialToWorld(q, r);
@@ -216,8 +446,9 @@ export function createBuildingMesh(buildingType, q, r, turnsRemaining, level) {
 
     const opacity = turnsRemaining > 0 ? 0.5 + 0.5 * progressFraction : 1;
 
-    // Slightly brighten color at higher levels
-    const baseColor = new THREE.Color(def.color);
+    // Use race-specific color if race provided
+    var colorHex = race ? getBuildingColor(buildingType, race) : def.color;
+    const baseColor = new THREE.Color(colorHex);
     if (level > 1) {
         baseColor.offsetHSL(0, 0, (level - 1) * 0.08);
     }

--- a/game-demo/js/game-state.js
+++ b/game-demo/js/game-state.js
@@ -1,7 +1,8 @@
 // game-state.js — Central game state (serializable)
-// Stores turn, race, resources, buildings, population, hex improvements
+// Stores turn, race, resources, buildings, population, hex improvements, tech research
 
 import { STARTING_RESOURCES } from './resources.js';
+import { createTechState } from './tech-tree.js';
 
 const SAVE_KEY = 'thunderclaw_hex_save';
 
@@ -15,6 +16,7 @@ export function createGameState(race) {
         population: { current: 5, cap: 5 },  // Town Center gives 5 starting pop
         hexImprovements: [],    // { q, r, turnsRemaining, bonus }
         exploredHexes: [],      // "q,r" keys
+        techState: createTechState(race),  // tech research progress
     };
 }
 

--- a/game-demo/js/resources.js
+++ b/game-demo/js/resources.js
@@ -19,10 +19,11 @@ export const STARTING_RESOURCES = {
 };
 
 // Race bonuses (multiplier applied to base gathering rate)
+// Expanded: each race now has stronger identity
 export const RACE_BONUSES = {
-    human: { food: 1, wood: 1,   stone: 1,   gold: 1.5, mana: 1 },
-    elf:   { food: 1, wood: 1.5, stone: 1,   gold: 1,   mana: 1.3 },
-    orc:   { food: 1, wood: 1,   stone: 1.5, gold: 1,   mana: 1 },
+    human: { food: 1.1, wood: 1,   stone: 1,   gold: 1.5, mana: 1 },
+    elf:   { food: 1,   wood: 1.5, stone: 0.8, gold: 1,   mana: 1.4 },
+    orc:   { food: 1.2, wood: 0.9, stone: 1.5, gold: 1,   mana: 0.8 },
 };
 
 // Terrain bonuses — passive resource bonus per turn for buildings on matching terrain

--- a/game-demo/js/tech-tree.js
+++ b/game-demo/js/tech-tree.js
@@ -1,0 +1,423 @@
+// tech-tree.js — Race-specific tech trees with prerequisites, research costs, and unlocks
+// Each race has 3 branches: Economy, Military, Magic
+// Techs unlock race-specific buildings, upgrades, and abilities
+
+// Tech node states
+export const TECH_STATE = {
+    locked: 'locked',       // Prerequisites not met
+    available: 'available', // Can be researched
+    researching: 'researching', // Currently being researched
+    completed: 'completed',     // Done
+};
+
+// ── Human Tech Tree ──
+// Economy & diplomacy focus
+const HUMAN_TREE = {
+    // Economy branch
+    agriculture: {
+        name: 'Agriculture',
+        branch: 'economy',
+        cost: { food: 20, gold: 10 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['farm'] },
+        description: 'Unlocks Farm construction',
+    },
+    commerce: {
+        name: 'Commerce',
+        branch: 'economy',
+        cost: { food: 30, gold: 20 },
+        turnsToResearch: 4,
+        prerequisites: ['agriculture'],
+        unlocks: { buildings: ['market'] },
+        description: 'Unlocks Market — generates gold',
+    },
+    masonry: {
+        name: 'Masonry',
+        branch: 'economy',
+        cost: { wood: 20, stone: 15, gold: 10 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['quarry', 'walls'] },
+        description: 'Unlocks Quarry and Walls',
+    },
+    mining: {
+        name: 'Mining',
+        branch: 'economy',
+        cost: { wood: 25, stone: 20, gold: 15 },
+        turnsToResearch: 4,
+        prerequisites: ['masonry'],
+        unlocks: { buildings: ['mine'] },
+        description: 'Unlocks Mine construction',
+    },
+    // Military branch
+    militia: {
+        name: 'Militia',
+        branch: 'military',
+        cost: { food: 25, wood: 15, gold: 15 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['barracks'] },
+        description: 'Unlocks Barracks',
+    },
+    fortification: {
+        name: 'Fortification',
+        branch: 'military',
+        cost: { wood: 30, stone: 40, gold: 20 },
+        turnsToResearch: 5,
+        prerequisites: ['militia', 'masonry'],
+        unlocks: { buildings: ['castle'] },
+        description: 'Unlocks Castle — strong defense',
+    },
+    // Magic branch
+    scripture: {
+        name: 'Scripture',
+        branch: 'magic',
+        cost: { gold: 25, mana: 10 },
+        turnsToResearch: 4,
+        prerequisites: [],
+        unlocks: { buildings: ['chapel'] },
+        description: 'Unlocks Chapel — generates mana',
+    },
+    arcane_studies: {
+        name: 'Arcane Studies',
+        branch: 'magic',
+        cost: { gold: 30, mana: 20 },
+        turnsToResearch: 5,
+        prerequisites: ['scripture'],
+        unlocks: { buildings: ['mage_tower'] },
+        description: 'Unlocks Mage Tower',
+    },
+    divine_mandate: {
+        name: 'Divine Mandate',
+        branch: 'magic',
+        cost: { food: 50, gold: 60, mana: 30 },
+        turnsToResearch: 8,
+        prerequisites: ['fortification', 'arcane_studies'],
+        unlocks: { buildings: ['grand_cathedral'] },
+        description: 'Unlocks Grand Cathedral — ultimate building',
+    },
+};
+
+// ── Elf Tech Tree ──
+// Magic & nature focus
+const ELF_TREE = {
+    // Economy branch
+    herbalism: {
+        name: 'Herbalism',
+        branch: 'economy',
+        cost: { food: 15, wood: 10 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['farm'] },
+        description: 'Unlocks Farm construction',
+    },
+    forestry: {
+        name: 'Forestry',
+        branch: 'economy',
+        cost: { food: 15, wood: 20 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['lumber_mill'] },
+        description: 'Unlocks Lumber Mill',
+    },
+    nature_bond: {
+        name: 'Nature Bond',
+        branch: 'economy',
+        cost: { wood: 30, mana: 15 },
+        turnsToResearch: 4,
+        prerequisites: ['forestry'],
+        unlocks: { buildings: ['tree_of_life'] },
+        description: 'Unlocks Tree of Life — wood & pop',
+    },
+    stonecraft: {
+        name: 'Stonecraft',
+        branch: 'economy',
+        cost: { wood: 20, stone: 15, gold: 10 },
+        turnsToResearch: 4,
+        prerequisites: [],
+        unlocks: { buildings: ['quarry', 'mine', 'walls'] },
+        description: 'Unlocks Quarry, Mine, and Walls',
+    },
+    // Military branch
+    sentinels: {
+        name: 'Sentinels',
+        branch: 'military',
+        cost: { wood: 20, gold: 15, mana: 5 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['barracks'] },
+        description: 'Unlocks Barracks',
+    },
+    // Magic branch
+    moonlight: {
+        name: 'Moonlight',
+        branch: 'magic',
+        cost: { wood: 15, mana: 15 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['moonwell'] },
+        description: 'Unlocks Moonwell — mana & healing',
+    },
+    arcane_lore: {
+        name: 'Arcane Lore',
+        branch: 'magic',
+        cost: { gold: 20, mana: 20 },
+        turnsToResearch: 4,
+        prerequisites: ['moonlight'],
+        unlocks: { buildings: ['mage_tower'] },
+        description: 'Unlocks Mage Tower',
+    },
+    ancient_knowledge: {
+        name: 'Ancient Knowledge',
+        branch: 'magic',
+        cost: { wood: 25, gold: 25, mana: 25 },
+        turnsToResearch: 5,
+        prerequisites: ['arcane_lore'],
+        unlocks: { buildings: ['ancient_archive'] },
+        description: 'Unlocks Ancient Archive — powerful magic',
+    },
+    world_tree: {
+        name: 'World Tree',
+        branch: 'magic',
+        cost: { wood: 60, gold: 40, mana: 50 },
+        turnsToResearch: 8,
+        prerequisites: ['nature_bond', 'ancient_knowledge'],
+        unlocks: { buildings: ['world_tree'] },
+        description: 'Unlocks World Tree — ultimate building',
+    },
+};
+
+// ── Orc Tech Tree ──
+// Military & raiding focus
+const ORC_TREE = {
+    // Economy branch
+    foraging: {
+        name: 'Foraging',
+        branch: 'economy',
+        cost: { food: 15, stone: 10 },
+        turnsToResearch: 2,
+        prerequisites: [],
+        unlocks: { buildings: ['farm'] },
+        description: 'Unlocks Farm construction',
+    },
+    logging: {
+        name: 'Logging',
+        branch: 'economy',
+        cost: { food: 10, wood: 10, stone: 5 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['lumber_mill'] },
+        description: 'Unlocks Lumber Mill',
+    },
+    excavation: {
+        name: 'Excavation',
+        branch: 'economy',
+        cost: { food: 15, stone: 20, gold: 5 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['quarry', 'mine', 'walls'] },
+        description: 'Unlocks Quarry, Mine, and Walls',
+    },
+    // Military branch
+    war_drums: {
+        name: 'War Drums',
+        branch: 'military',
+        cost: { food: 20, stone: 15 },
+        turnsToResearch: 2,
+        prerequisites: [],
+        unlocks: { buildings: ['barracks'] },
+        description: 'Unlocks Barracks',
+    },
+    blood_forge_tech: {
+        name: 'Blood Smithing',
+        branch: 'military',
+        cost: { food: 30, stone: 30, gold: 15 },
+        turnsToResearch: 4,
+        prerequisites: ['war_drums', 'excavation'],
+        unlocks: { buildings: ['blood_forge'] },
+        description: 'Unlocks Blood Forge — weapons & armor',
+    },
+    war_pit_tech: {
+        name: 'War Pits',
+        branch: 'military',
+        cost: { food: 40, stone: 25, gold: 20 },
+        turnsToResearch: 5,
+        prerequisites: ['blood_forge_tech'],
+        unlocks: { buildings: ['war_pit'] },
+        description: 'Unlocks War Pit — elite warriors',
+    },
+    // Magic branch
+    spirit_call: {
+        name: 'Spirit Call',
+        branch: 'magic',
+        cost: { food: 15, stone: 10, mana: 10 },
+        turnsToResearch: 3,
+        prerequisites: [],
+        unlocks: { buildings: ['totem'] },
+        description: 'Unlocks Totem — spiritual power',
+    },
+    shamanism: {
+        name: 'Shamanism',
+        branch: 'magic',
+        cost: { stone: 20, gold: 15, mana: 15 },
+        turnsToResearch: 4,
+        prerequisites: ['spirit_call'],
+        unlocks: { buildings: ['mage_tower'] },
+        description: 'Unlocks Mage Tower',
+    },
+    warlord_ascension: {
+        name: 'Warlord Ascension',
+        branch: 'magic',
+        cost: { food: 60, stone: 50, gold: 30, mana: 20 },
+        turnsToResearch: 8,
+        prerequisites: ['war_pit_tech', 'shamanism'],
+        unlocks: { buildings: ['skull_throne'] },
+        description: 'Unlocks Skull Throne — ultimate building',
+    },
+};
+
+// All race trees
+export const RACE_TECH_TREES = {
+    human: HUMAN_TREE,
+    elf: ELF_TREE,
+    orc: ORC_TREE,
+};
+
+// Initialize tech research state for a race
+export function createTechState(race) {
+    var tree = RACE_TECH_TREES[race];
+    var state = {};
+    for (var id in tree) {
+        state[id] = {
+            status: TECH_STATE.locked,
+            turnsRemaining: 0,
+        };
+    }
+    // Unlock techs with no prerequisites
+    for (var id2 in tree) {
+        if (tree[id2].prerequisites.length === 0) {
+            state[id2].status = TECH_STATE.available;
+        }
+    }
+    return state;
+}
+
+// Check if a tech can be researched
+export function canResearchTech(techId, race, techState, resources) {
+    var tree = RACE_TECH_TREES[race];
+    var tech = tree[techId];
+    if (!tech) return { ok: false, reason: 'Unknown tech' };
+
+    var ts = techState[techId];
+    if (ts.status === TECH_STATE.completed) return { ok: false, reason: 'Already researched' };
+    if (ts.status === TECH_STATE.researching) return { ok: false, reason: 'Already researching' };
+    if (ts.status === TECH_STATE.locked) return { ok: false, reason: 'Prerequisites not met' };
+
+    // Check if already researching something else
+    for (var id in techState) {
+        if (techState[id].status === TECH_STATE.researching) {
+            return { ok: false, reason: 'Already researching ' + tree[id].name };
+        }
+    }
+
+    // Check resources
+    for (var res in tech.cost) {
+        if ((resources[res] || 0) < tech.cost[res]) {
+            return { ok: false, reason: 'Not enough ' + res };
+        }
+    }
+
+    return { ok: true };
+}
+
+// Start researching a tech
+export function startResearch(techId, race, techState, resources) {
+    var tree = RACE_TECH_TREES[race];
+    var tech = tree[techId];
+
+    // Deduct cost
+    var newResources = {};
+    for (var res in resources) {
+        newResources[res] = resources[res];
+    }
+    for (var res2 in tech.cost) {
+        newResources[res2] -= tech.cost[res2];
+    }
+
+    techState[techId].status = TECH_STATE.researching;
+    techState[techId].turnsRemaining = tech.turnsToResearch;
+
+    return newResources;
+}
+
+// Advance research by one turn — returns list of completed tech ids
+export function advanceResearch(race, techState) {
+    var tree = RACE_TECH_TREES[race];
+    var completed = [];
+
+    for (var id in techState) {
+        if (techState[id].status === TECH_STATE.researching) {
+            techState[id].turnsRemaining -= 1;
+            if (techState[id].turnsRemaining <= 0) {
+                techState[id].status = TECH_STATE.completed;
+                completed.push(id);
+            }
+        }
+    }
+
+    // Update available techs based on newly completed prerequisites
+    if (completed.length > 0) {
+        updateAvailableTechs(race, techState);
+    }
+
+    return completed;
+}
+
+// Recalculate which techs are available based on completed prerequisites
+export function updateAvailableTechs(race, techState) {
+    var tree = RACE_TECH_TREES[race];
+    for (var id in tree) {
+        if (techState[id].status !== TECH_STATE.locked) continue;
+        var prereqs = tree[id].prerequisites;
+        var allMet = true;
+        for (var i = 0; i < prereqs.length; i++) {
+            if (!techState[prereqs[i]] || techState[prereqs[i]].status !== TECH_STATE.completed) {
+                allMet = false;
+                break;
+            }
+        }
+        if (allMet) {
+            techState[id].status = TECH_STATE.available;
+        }
+    }
+}
+
+// Get set of all buildings unlocked by completed techs
+export function getUnlockedBuildings(race, techState) {
+    var tree = RACE_TECH_TREES[race];
+    var unlocked = new Set();
+    // Town Center is always available
+    unlocked.add('town_center');
+    for (var id in techState) {
+        if (techState[id].status === TECH_STATE.completed) {
+            var tech = tree[id];
+            if (tech.unlocks && tech.unlocks.buildings) {
+                for (var i = 0; i < tech.unlocks.buildings.length; i++) {
+                    unlocked.add(tech.unlocks.buildings[i]);
+                }
+            }
+        }
+    }
+    return unlocked;
+}
+
+// Get the currently researching tech (or null)
+export function getCurrentResearch(techState) {
+    for (var id in techState) {
+        if (techState[id].status === TECH_STATE.researching) {
+            return id;
+        }
+    }
+    return null;
+}

--- a/game-demo/js/turn.js
+++ b/game-demo/js/turn.js
@@ -1,9 +1,10 @@
-// turn.js — Turn system: end turn, gather resources, advance construction, hex improvements
+// turn.js — Turn system: end turn, gather resources, advance construction, hex improvements, tech research
 
 import { BUILDING_TYPES, recalcPopulationCap } from './buildings.js';
 import { gatherResources, TERRAIN_BONUSES } from './resources.js';
+import { advanceResearch } from './tech-tree.js';
 
-// Process end of turn: gather resources, advance construction, process hex improvements
+// Process end of turn: gather resources, advance construction, process hex improvements, advance research
 // hexData: Map of "q,r" -> hex object (for terrain lookup)
 export function processTurn(state, onBuildingComplete, hexData) {
     state.turn += 1;
@@ -76,6 +77,12 @@ export function processTurn(state, onBuildingComplete, hexData) {
         }
     }
 
+    // Advance tech research
+    var completedTechs = [];
+    if (state.techState) {
+        completedTechs = advanceResearch(state.race, state.techState);
+    }
+
     // Recalculate population cap
     recalcPopulationCap(state);
 
@@ -85,5 +92,5 @@ export function processTurn(state, onBuildingComplete, hexData) {
         state.resources.food -= 5;
     }
 
-    return gathered;
+    return { gathered: gathered, completedTechs: completedTechs };
 }


### PR DESCRIPTION
Closes #14

## Acceptance Criteria

- [x] Race-specific building variants
  - Humans: Castle, Market, Chapel → economy & diplomacy focus
  - Elves: Tree of Life, Moonwell, Ancient Archive → magic & nature focus
  - Orcs: War Pit, Blood Forge, Totem → military & raiding focus
- [x] Tech tree system (`/game-demo/js/tech-tree.js`)
  - Tree structure with prerequisites
  - Research costs resources + turns
  - Unlocks buildings, upgrades, abilities
  - 3 branches per race: Economy, Military, Magic
  - UI: tree visualization panel (HTML overlay with connections)
- [x] Race-specific color palettes for buildings
  - Humans: stone gray / blue
  - Elves: wood brown / emerald green / silver
  - Orcs: dark iron / red / bone white
- [x] Race-specific resource bonuses (expand from Phase 1B basics)
- [x] Unique "ultimate" building per race (late-game unlock)
  - Human: Grand Cathedral
  - Elf: World Tree
  - Orc: Skull Throne

## Changes
- **New file**: `game-demo/js/tech-tree.js` — full tech tree system with 3 branches per race, prerequisites, research costs/turns, and unlock tracking
- **Updated**: `game-demo/js/buildings.js` — added 10 new race-specific buildings (3 per race + 1 ultimate each), race color palettes, `getBuildingsForRace()` and `getBuildingColor()` helpers
- **Updated**: `game-demo/js/resources.js` — expanded race bonuses (Humans +10% food, Elves +40% mana/-20% stone, Orcs +20% food/-10% wood/-20% mana)
- **Updated**: `game-demo/js/game-state.js` — tech state integrated into game state, backward-compatible with old saves
- **Updated**: `game-demo/js/turn.js` — tech research advances each turn, returns completed techs
- **Updated**: `game-demo/js/main.js` — build menu filtered by tech unlocks, tech tree panel toggle, research status HUD
- **Updated**: `game-demo/index.html` — tech tree overlay panel, research status bar, tech tree button, updated race cards with building info