### PR TITLE
Game Demo: Multiplayer via Supabase Realtime — rooms, turns & sync

### DIFF
--- a/game-demo/index.html
+++ b/game-demo/index.html
@@ -1464,6 +1464,407 @@
         .resource-change.positive { color: #4ade80; }
         .resource-change.negative { color: #ef4444; }
 
+        /* ── Multiplayer UI ── */
+        #mp-btn {
+            display: block;
+            margin-top: 0.5rem;
+            background: var(--surface);
+            border: 2px solid var(--accent-dim);
+            border-radius: 8px;
+            padding: 0.5rem 1.5rem;
+            color: var(--accent);
+            font-size: 0.95rem;
+            font-weight: 600;
+            font-family: inherit;
+            cursor: pointer;
+            transition: border-color 0.2s, transform 0.1s;
+        }
+
+        #mp-btn:hover {
+            border-color: var(--accent);
+            transform: translateY(-2px);
+        }
+
+        /* Multiplayer lobby modal */
+        #mp-lobby {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 110;
+            background: rgba(10, 10, 15, 0.95);
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 1.5rem;
+        }
+
+        #mp-lobby.visible {
+            display: flex;
+        }
+
+        .mp-lobby-title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--accent);
+        }
+
+        .mp-lobby-section {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 1.2rem 1.6rem;
+            min-width: 300px;
+            text-align: center;
+        }
+
+        .mp-lobby-section h3 {
+            font-size: 1rem;
+            color: var(--accent);
+            margin-bottom: 0.8rem;
+        }
+
+        .mp-lobby-section input {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 0.5rem 0.8rem;
+            color: var(--text);
+            font-size: 1.2rem;
+            font-family: inherit;
+            text-align: center;
+            text-transform: uppercase;
+            letter-spacing: 0.2em;
+            width: 120px;
+            margin-right: 0.5rem;
+        }
+
+        .mp-lobby-section input:focus {
+            outline: none;
+            border-color: var(--accent);
+        }
+
+        .mp-lobby-btn {
+            background: var(--accent);
+            border: none;
+            border-radius: 6px;
+            padding: 0.5rem 1.2rem;
+            color: var(--bg);
+            font-size: 0.9rem;
+            font-weight: 600;
+            font-family: inherit;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .mp-lobby-btn:hover {
+            background: #e5a91f;
+        }
+
+        .mp-lobby-btn.secondary {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            color: var(--text);
+        }
+
+        .mp-lobby-btn.secondary:hover {
+            border-color: var(--accent);
+        }
+
+        .mp-room-code {
+            font-size: 2rem;
+            font-weight: 700;
+            color: var(--accent);
+            letter-spacing: 0.3em;
+            margin: 0.5rem 0;
+            font-family: monospace;
+        }
+
+        .mp-room-info {
+            color: var(--muted);
+            font-size: 0.85rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .mp-players {
+            margin: 0.8rem 0;
+            text-align: left;
+        }
+
+        .mp-player-row {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.3rem 0;
+            font-size: 0.9rem;
+        }
+
+        .mp-player-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #10b981;
+        }
+
+        .mp-player-dot.waiting {
+            background: var(--muted);
+        }
+
+        .mp-player-name {
+            color: var(--text);
+            font-weight: 600;
+        }
+
+        .mp-player-race {
+            color: var(--muted);
+            font-size: 0.8rem;
+        }
+
+        .mp-player-status {
+            margin-left: auto;
+            font-size: 0.75rem;
+            color: #10b981;
+        }
+
+        .mp-player-status.not-ready {
+            color: var(--muted);
+        }
+
+        /* Connection status indicator */
+        #mp-status {
+            position: fixed;
+            top: 1rem;
+            right: 16rem;
+            z-index: 10;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 0.35rem 0.7rem;
+            display: none;
+            align-items: center;
+            gap: 0.4rem;
+            font-size: 0.75rem;
+        }
+
+        #mp-status.visible {
+            display: flex;
+        }
+
+        .mp-status-dot {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: #10b981;
+        }
+
+        .mp-status-dot.disconnected {
+            background: #ef4444;
+        }
+
+        .mp-status-text {
+            color: var(--muted);
+        }
+
+        /* Waiting overlay during opponent's turn */
+        #mp-waiting {
+            position: fixed;
+            bottom: 4rem;
+            right: 1rem;
+            z-index: 10;
+            background: var(--surface);
+            border: 1px solid var(--accent-dim);
+            border-radius: 8px;
+            padding: 0.6rem 1.2rem;
+            display: none;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.9rem;
+            color: var(--accent);
+            font-weight: 600;
+        }
+
+        #mp-waiting.visible {
+            display: flex;
+        }
+
+        .mp-waiting-spinner {
+            width: 14px;
+            height: 14px;
+            border: 2px solid var(--accent-dim);
+            border-top-color: var(--accent);
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        /* Chat panel */
+        #mp-chat {
+            position: fixed;
+            bottom: 1rem;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 10;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            width: 300px;
+            display: none;
+            flex-direction: column;
+            max-height: 250px;
+        }
+
+        #mp-chat.visible {
+            display: flex;
+        }
+
+        .mp-chat-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0.4rem 0.6rem;
+            border-bottom: 1px solid var(--border);
+            font-size: 0.75rem;
+            color: var(--muted);
+        }
+
+        #mp-chat-close {
+            background: none;
+            border: none;
+            color: var(--muted);
+            cursor: pointer;
+            font-size: 0.8rem;
+            font-family: inherit;
+        }
+
+        #mp-chat-close:hover {
+            color: var(--text);
+        }
+
+        #mp-chat-messages {
+            flex: 1;
+            overflow-y: auto;
+            padding: 0.4rem 0.6rem;
+            max-height: 160px;
+            font-size: 0.8rem;
+        }
+
+        .mp-chat-msg {
+            margin-bottom: 0.3rem;
+            line-height: 1.4;
+        }
+
+        .mp-chat-msg .from-you {
+            color: var(--accent);
+            font-weight: 600;
+        }
+
+        .mp-chat-msg .from-opp {
+            color: #60a5fa;
+            font-weight: 600;
+        }
+
+        .mp-chat-input-row {
+            display: flex;
+            border-top: 1px solid var(--border);
+        }
+
+        #mp-chat-input {
+            flex: 1;
+            background: var(--bg);
+            border: none;
+            padding: 0.4rem 0.6rem;
+            color: var(--text);
+            font-size: 0.8rem;
+            font-family: inherit;
+            border-radius: 0 0 0 8px;
+        }
+
+        #mp-chat-input:focus {
+            outline: none;
+        }
+
+        #mp-chat-send {
+            background: var(--accent-dim);
+            border: none;
+            padding: 0.4rem 0.8rem;
+            color: var(--accent);
+            font-size: 0.8rem;
+            font-weight: 600;
+            font-family: inherit;
+            cursor: pointer;
+            border-radius: 0 0 8px 0;
+        }
+
+        #mp-chat-send:hover {
+            background: var(--accent);
+            color: var(--bg);
+        }
+
+        /* Chat toggle button */
+        #mp-chat-toggle {
+            position: fixed;
+            bottom: 1rem;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 10;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 0.4rem 0.8rem;
+            font-size: 0.8rem;
+            font-family: inherit;
+            color: var(--text);
+            cursor: pointer;
+            display: none;
+            transition: border-color 0.2s;
+        }
+
+        #mp-chat-toggle.visible {
+            display: block;
+        }
+
+        #mp-chat-toggle:hover {
+            border-color: var(--accent);
+        }
+
+        /* Disconnected notification */
+        #mp-disconnect-notice {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            z-index: 90;
+            background: var(--surface);
+            border: 2px solid #ef4444;
+            border-radius: 12px;
+            padding: 1.2rem 1.6rem;
+            text-align: center;
+            display: none;
+            min-width: 280px;
+        }
+
+        #mp-disconnect-notice.visible {
+            display: block;
+        }
+
+        .mp-disconnect-title {
+            font-size: 1rem;
+            font-weight: 700;
+            color: #ef4444;
+            margin-bottom: 0.4rem;
+        }
+
+        .mp-disconnect-text {
+            font-size: 0.85rem;
+            color: var(--muted);
+            margin-bottom: 0.8rem;
+        }
+
         /* ── Touch-friendly adjustments ── */
         @media (pointer: coarse) {
             #end-turn-btn {
@@ -1577,6 +1978,7 @@
             </div>
         </div>
         <button id="continue-btn">Continue Saved Game</button>
+        <button id="mp-btn">Multiplayer</button>
     </div>
 
     <div class="hud-header">
@@ -1690,6 +2092,72 @@
         <button class="sound-btn active" id="sfx-toggle" title="Sound Effects">SFX</button>
         <button class="sound-btn active" id="music-toggle" title="Music">MUS</button>
     </div>
+
+    <!-- Multiplayer Lobby Modal -->
+    <div id="mp-lobby">
+        <div class="mp-lobby-title">Multiplayer</div>
+        <div class="mp-lobby-section" id="mp-lobby-menu">
+            <h3>Play with a friend</h3>
+            <button class="mp-lobby-btn" id="mp-host-btn">Host Game</button>
+            <div style="margin: 0.8rem 0; color: var(--muted); font-size: 0.85rem">— or —</div>
+            <div>
+                <input type="text" id="mp-join-code" maxlength="4" placeholder="CODE">
+                <button class="mp-lobby-btn" id="mp-join-btn">Join</button>
+            </div>
+            <div style="margin-top: 1rem">
+                <button class="mp-lobby-btn secondary" id="mp-lobby-close">Back</button>
+            </div>
+        </div>
+        <div class="mp-lobby-section" id="mp-lobby-room" style="display:none">
+            <div class="mp-room-info">Room Code</div>
+            <div class="mp-room-code" id="mp-room-code-display"></div>
+            <div class="mp-room-info">Share this code with your friend</div>
+            <div class="mp-players" id="mp-players-list"></div>
+            <div style="margin-top: 0.8rem; display: flex; gap: 0.5rem; justify-content: center">
+                <button class="mp-lobby-btn" id="mp-ready-btn" disabled>Ready</button>
+                <button class="mp-lobby-btn" id="mp-start-btn" style="display:none">Start Game</button>
+                <button class="mp-lobby-btn secondary" id="mp-leave-btn">Leave</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Multiplayer connection status indicator -->
+    <div id="mp-status">
+        <div class="mp-status-dot" id="mp-status-dot"></div>
+        <span class="mp-status-text" id="mp-status-text">Connected</span>
+    </div>
+
+    <!-- Waiting for opponent overlay -->
+    <div id="mp-waiting">
+        <div class="mp-waiting-spinner"></div>
+        <span>Waiting for opponent...</span>
+    </div>
+
+    <!-- Chat toggle button -->
+    <button id="mp-chat-toggle">Chat</button>
+
+    <!-- Chat panel -->
+    <div id="mp-chat">
+        <div class="mp-chat-header">
+            <span>Chat</span>
+            <button id="mp-chat-close">X</button>
+        </div>
+        <div id="mp-chat-messages"></div>
+        <div class="mp-chat-input-row">
+            <input type="text" id="mp-chat-input" placeholder="Type a message..." maxlength="200">
+            <button id="mp-chat-send">Send</button>
+        </div>
+    </div>
+
+    <!-- Opponent disconnected notice -->
+    <div id="mp-disconnect-notice">
+        <div class="mp-disconnect-title">Opponent Disconnected</div>
+        <div class="mp-disconnect-text">Waiting for reconnection... Auto-forfeit in 5 minutes.</div>
+        <button class="mp-lobby-btn secondary" id="mp-disconnect-dismiss">OK</button>
+    </div>
+
+    <!-- Supabase JS client from CDN -->
+    <script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 
     <script type="importmap">
     {

--- a/game-demo/js/multiplayer.js
+++ b/game-demo/js/multiplayer.js
@@ -1,0 +1,331 @@
+// multiplayer.js — Supabase Realtime multiplayer: lobby, sync, chat & connection handling
+// Two-player turn-based: host creates room, guest joins with 4-char code.
+// Uses Broadcast for game actions, Presence for lobby state.
+
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase-config.js';
+import { serializeState, deserializeState } from './game-state.js';
+
+// ── State ──
+var supabase = null;
+var channel = null;
+var roomCode = null;
+var playerId = null;
+var isHost = false;
+var opponentId = null;
+var opponentRace = null;
+var opponentReady = false;
+var connected = false;
+var disconnectTimer = null;
+var onActionCallback = null;
+var onChatCallback = null;
+var onPresenceCallback = null;
+var onDisconnectCallback = null;
+var onReconnectCallback = null;
+var onForfeitCallback = null;
+var myTurn = false;
+
+// Timeout for auto-forfeit (5 minutes)
+var DISCONNECT_TIMEOUT = 5 * 60 * 1000;
+
+// ── Generate a random 4-char room code ──
+function generateRoomCode() {
+    var chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    var code = '';
+    for (var i = 0; i < 4; i++) {
+        code += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return code;
+}
+
+// ── Generate a random player ID ──
+function generatePlayerId() {
+    return 'p_' + Math.random().toString(36).substr(2, 9);
+}
+
+// ── Initialize Supabase client ──
+function initSupabase() {
+    if (supabase) return supabase;
+
+    if (typeof window.supabase === 'undefined' || !window.supabase.createClient) {
+        console.error('Supabase JS client not loaded. Add the CDN script to index.html.');
+        return null;
+    }
+
+    supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+        realtime: {
+            params: { eventsPerSecond: 10 },
+        },
+    });
+
+    playerId = generatePlayerId();
+    return supabase;
+}
+
+// ── Create a room (host) ──
+export function createRoom(race, callbacks) {
+    var client = initSupabase();
+    if (!client) return null;
+
+    isHost = true;
+    roomCode = generateRoomCode();
+    myTurn = true; // Host goes first
+    setCallbacks(callbacks);
+    joinChannel(race);
+    return roomCode;
+}
+
+// ── Join a room (guest) ──
+export function joinRoom(code, race, callbacks) {
+    var client = initSupabase();
+    if (!client) return false;
+
+    isHost = false;
+    roomCode = code.toUpperCase();
+    myTurn = false; // Guest goes second
+    setCallbacks(callbacks);
+    joinChannel(race);
+    return true;
+}
+
+function setCallbacks(callbacks) {
+    onActionCallback = callbacks.onAction || null;
+    onChatCallback = callbacks.onChat || null;
+    onPresenceCallback = callbacks.onPresence || null;
+    onDisconnectCallback = callbacks.onDisconnect || null;
+    onReconnectCallback = callbacks.onReconnect || null;
+    onForfeitCallback = callbacks.onForfeit || null;
+}
+
+// ── Join the Supabase Realtime channel ──
+function joinChannel(race) {
+    if (!supabase || !roomCode) return;
+
+    channel = supabase.channel('room-' + roomCode, {
+        config: {
+            broadcast: { self: false },
+            presence: { key: playerId },
+        },
+    });
+
+    // Presence: track who is in the room
+    channel.on('presence', { event: 'sync' }, function () {
+        var state = channel.presenceState();
+        handlePresenceSync(state);
+    });
+
+    channel.on('presence', { event: 'join' }, function (payload) {
+        clearDisconnectTimer();
+        if (onReconnectCallback) onReconnectCallback();
+    });
+
+    channel.on('presence', { event: 'leave' }, function (payload) {
+        handlePresenceLeave(payload);
+    });
+
+    // Broadcast: game actions
+    channel.on('broadcast', { event: 'game-action' }, function (payload) {
+        handleGameAction(payload.payload);
+    });
+
+    // Broadcast: chat messages
+    channel.on('broadcast', { event: 'chat' }, function (payload) {
+        handleChat(payload.payload);
+    });
+
+    // Broadcast: full state sync (for catch-up on join)
+    channel.on('broadcast', { event: 'state-sync' }, function (payload) {
+        handleStateSync(payload.payload);
+    });
+
+    channel.subscribe(function (status) {
+        if (status === 'SUBSCRIBED') {
+            connected = true;
+            channel.track({
+                playerId: playerId,
+                race: race,
+                isHost: isHost,
+                ready: false,
+            });
+        }
+    });
+}
+
+// ── Presence handlers ──
+function handlePresenceSync(state) {
+    var players = [];
+    for (var key in state) {
+        var presences = state[key];
+        for (var i = 0; i < presences.length; i++) {
+            players.push(presences[i]);
+        }
+    }
+
+    // Find opponent
+    opponentId = null;
+    opponentRace = null;
+    opponentReady = false;
+    for (var j = 0; j < players.length; j++) {
+        if (players[j].playerId !== playerId) {
+            opponentId = players[j].playerId;
+            opponentRace = players[j].race;
+            opponentReady = players[j].ready || false;
+        }
+    }
+
+    if (onPresenceCallback) {
+        onPresenceCallback({
+            players: players,
+            opponentId: opponentId,
+            opponentRace: opponentRace,
+            opponentReady: opponentReady,
+            roomCode: roomCode,
+            isHost: isHost,
+        });
+    }
+}
+
+function handlePresenceLeave(payload) {
+    if (!payload || !payload.leftPresences) return;
+
+    for (var i = 0; i < payload.leftPresences.length; i++) {
+        if (payload.leftPresences[i].playerId !== playerId) {
+            connected = false;
+            if (onDisconnectCallback) onDisconnectCallback();
+            startDisconnectTimer();
+        }
+    }
+}
+
+// ── Disconnect timer for auto-forfeit ──
+function startDisconnectTimer() {
+    clearDisconnectTimer();
+    disconnectTimer = setTimeout(function () {
+        if (onForfeitCallback) onForfeitCallback();
+    }, DISCONNECT_TIMEOUT);
+}
+
+function clearDisconnectTimer() {
+    if (disconnectTimer) {
+        clearTimeout(disconnectTimer);
+        disconnectTimer = null;
+    }
+}
+
+// ── Game action handling ──
+function handleGameAction(data) {
+    if (!data) return;
+
+    if (data.type === 'end-turn') {
+        myTurn = true;
+    }
+
+    if (onActionCallback) {
+        onActionCallback(data);
+    }
+}
+
+// ── Chat handling ──
+function handleChat(data) {
+    if (!data) return;
+    if (onChatCallback) {
+        onChatCallback({
+            from: data.playerId === playerId ? 'you' : 'opponent',
+            text: data.text,
+            timestamp: data.timestamp,
+        });
+    }
+}
+
+// ── State sync handling ──
+function handleStateSync(data) {
+    if (!data) return;
+    if (onActionCallback) {
+        onActionCallback({ type: 'state-sync', state: data.state });
+    }
+}
+
+// ── Send a game action ──
+export function sendAction(action) {
+    if (!channel) return;
+    channel.send({
+        type: 'broadcast',
+        event: 'game-action',
+        payload: {
+            playerId: playerId,
+            ...action,
+        },
+    });
+
+    if (action.type === 'end-turn') {
+        myTurn = false;
+    }
+}
+
+// ── Send a chat message ──
+export function sendChat(text) {
+    if (!channel || !text) return;
+    channel.send({
+        type: 'broadcast',
+        event: 'chat',
+        payload: {
+            playerId: playerId,
+            text: text,
+            timestamp: Date.now(),
+        },
+    });
+}
+
+// ── Send full state sync (host -> new joiner) ──
+export function sendStateSync(gameState) {
+    if (!channel) return;
+    channel.send({
+        type: 'broadcast',
+        event: 'state-sync',
+        payload: {
+            playerId: playerId,
+            state: serializeState(gameState),
+        },
+    });
+}
+
+// ── Mark self as ready ──
+export function setReady(race) {
+    if (!channel) return;
+    channel.track({
+        playerId: playerId,
+        race: race,
+        isHost: isHost,
+        ready: true,
+    });
+}
+
+// ── Leave the room ──
+export function leaveRoom() {
+    clearDisconnectTimer();
+    if (channel) {
+        channel.untrack();
+        channel.unsubscribe();
+        channel = null;
+    }
+    roomCode = null;
+    opponentId = null;
+    opponentRace = null;
+    opponentReady = false;
+    connected = false;
+    myTurn = false;
+}
+
+// ── Getters ──
+export function getRoomCode() { return roomCode; }
+export function getPlayerId() { return playerId; }
+export function getIsHost() { return isHost; }
+export function getIsMyTurn() { return myTurn; }
+export function setIsMyTurn(val) { myTurn = val; }
+export function getIsConnected() { return connected; }
+export function getOpponentRace() { return opponentRace; }
+export function getOpponentReady() { return opponentReady; }
+
+// ── Check if multiplayer mode is active ──
+export function isMultiplayerActive() {
+    return channel !== null && roomCode !== null;
+}

--- a/game-demo/js/supabase-config.js
+++ b/game-demo/js/supabase-config.js
@@ -1,0 +1,6 @@
+// supabase-config.js — Supabase connection configuration
+// Replace these with your actual Supabase project credentials
+// or set window.SUPABASE_URL / window.SUPABASE_ANON_KEY before loading.
+
+export const SUPABASE_URL = window.SUPABASE_URL || 'https://your-project.supabase.co';
+export const SUPABASE_ANON_KEY = window.SUPABASE_ANON_KEY || 'your-anon-key';


### PR DESCRIPTION
Closes #28

## Summary
- Adds two-player turn-based multiplayer using Supabase Realtime (Broadcast + Presence channels)
- Host creates a room with a 4-char code, guest joins by entering the code
- Lobby with player list, race display, and ready/start flow
- Turn-based gating: only the active player can take actions and end turn
- Chat via Broadcast channel
- Connection status indicator, "Waiting for opponent..." overlay, disconnect notification with 5-min auto-forfeit

## Acceptance Criteria
- [x] Supabase JS client loaded from CDN
- [x] Lobby system using Realtime Presence:
  - Create room (generates 4-char code)
  - Join room by code
  - Show connected players + their chosen race
  - "Start Game" when both players ready
- [x] Game sync using Realtime Broadcast:
  - `game-action` channel: build, move, end-turn, combat
  - Turn-based: only active player can send actions
  - Opponent receives and applies actions to local state
  - Full state sync on join (catch-up)
- [x] Connection handling:
  - Reconnection support (Supabase handles this)
  - "Opponent disconnected" notification
  - Timeout auto-forfeit after 5 min disconnect
- [x] UI:
  - Multiplayer button on start screen
  - Host/Join modal
  - Connection status indicator
  - "Waiting for opponent..." overlay during their turn
  - Chat (simple text messages via Broadcast)
- [x] Config: Supabase URL + anon key in game config (supabase-config.js)

## Test plan
- [ ] Verify build.py passes (static site build)
- [ ] Open game in two browser tabs, host in one, join in other with room code
- [ ] Verify presence shows both players with race selections
- [ ] Verify only active player can click hexes and end turn
- [ ] Verify chat messages appear in both tabs
- [ ] Verify disconnect notification appears when one tab closes
- [ ] Replace placeholder Supabase credentials with real project to test live