### PR TITLE
Skip GLTFLoader requests for missing .glb files (404 spam)

### DIFF
--- a/game-demo/js/asset-loader.js
+++ b/game-demo/js/asset-loader.js
@@ -36,7 +36,7 @@ var MODEL_REGISTRY = {
     'prop_rock_small': 'props/rock_small.glb',
     'prop_grass': 'props/grass.glb',
 
-    // Buildings (shared)
+    // Buildings (shared — only models with .glb files on disk)
     'building_town_center': 'buildings/town_center.glb',
     'building_farm': 'buildings/farm.glb',
     'building_lumber_mill': 'buildings/lumber_mill.glb',
@@ -45,24 +45,10 @@ var MODEL_REGISTRY = {
     'building_barracks': 'buildings/barracks.glb',
     'building_mage_tower': 'buildings/mage_tower.glb',
     'building_walls': 'buildings/walls.glb',
-
-    // Human buildings
-    'building_market': 'buildings/market.glb',
-    'building_castle': 'buildings/castle.glb',
-    'building_chapel': 'buildings/chapel.glb',
-    'building_grand_cathedral': 'buildings/grand_cathedral.glb',
-
-    // Elf buildings
-    'building_tree_of_life': 'buildings/tree_of_life.glb',
-    'building_moonwell': 'buildings/moonwell.glb',
-    'building_ancient_archive': 'buildings/ancient_archive.glb',
-    'building_world_tree': 'buildings/world_tree.glb',
-
-    // Orc buildings
-    'building_war_pit': 'buildings/war_pit.glb',
-    'building_blood_forge': 'buildings/blood_forge.glb',
-    'building_totem': 'buildings/totem.glb',
-    'building_skull_throne': 'buildings/skull_throne.glb',
+    // Race-specific buildings (market, castle, chapel, grand_cathedral,
+    // tree_of_life, moonwell, ancient_archive, world_tree, war_pit,
+    // blood_forge, totem, skull_throne) use procedural fallback —
+    // no .glb files shipped yet.
 
     // Units
     'unit_worker': 'units/worker.glb',


### PR DESCRIPTION
Closes #51

## Summary
- Removed 12 race-specific building entries from `MODEL_REGISTRY` in `asset-loader.js` that had no corresponding `.glb` files on disk
- These buildings (Human: market, castle, chapel, grand_cathedral; Elf: tree_of_life, moonwell, ancient_archive, world_tree; Orc: war_pit, blood_forge, totem, skull_throne) now skip the GLTF fetch entirely and go straight to their procedural fallback generators
- The 19 generic models (6 props, 8 shared buildings, 5 units) that have `.glb` files remain in the registry and load normally

## Acceptance Criteria
- [x] No 404 requests for non-existent .glb files
- [x] Generic models from PR #47 still load correctly
- [x] Race-specific buildings use procedural fallback silently
- [x] No console errors from missing model files
- [x] Mobile loading not delayed by failed fetches