### PR TITLE
UI regressions from PR #53: Build menu broken, click-through, overlaps

### DIFF
--- a/game-demo/index.html
+++ b/game-demo/index.html
@@ -80,7 +80,7 @@
         /* Controls hint */
         .hud-controls {
             position: fixed;
-            bottom: 11rem;
+            bottom: 17rem;
             left: 1rem;
             z-index: 9;
             background: var(--surface);

--- a/game-demo/js/input.js
+++ b/game-demo/js/input.js
@@ -179,18 +179,28 @@ export function setupInput(camera, hexMeshes, hexData, callbacks, gridApi) {
     function onClick(event) {
         // Ignore clicks on UI overlays
         if (event.target.closest('#build-menu') ||
-            event.target.closest('#end-turn-btn') ||
+            event.target.closest('#bottom-bar') ||
             event.target.closest('#race-select') ||
             event.target.closest('#resource-bar') ||
             event.target.closest('#turn-counter') ||
             event.target.closest('#pop-bar') ||
-            event.target.closest('#save-load-bar') ||
             event.target.closest('#minimap') ||
             event.target.closest('#pwa-install-banner') ||
             event.target.closest('#sound-controls') ||
-            event.target.closest('#tech-tree-btn') ||
-            event.target.closest('#event-log-btn') ||
-            event.target.closest('#quest-panel')) {
+            event.target.closest('#quest-panel') ||
+            event.target.closest('#hex-info') ||
+            event.target.closest('#combat-log') ||
+            event.target.closest('.hud-controls') ||
+            event.target.closest('#tech-tree-panel') ||
+            event.target.closest('#event-log-panel') ||
+            event.target.closest('#event-toast') ||
+            event.target.closest('#tutorial-overlay') ||
+            event.target.closest('#game-over-screen') ||
+            event.target.closest('#mp-lobby') ||
+            event.target.closest('#mp-chat') ||
+            event.target.closest('#mp-chat-toggle') ||
+            event.target.closest('#anim-speed-bar') ||
+            event.target.closest('#research-status')) {
             return;
         }
 
@@ -298,18 +308,28 @@ export function setupInput(camera, hexMeshes, hexData, callbacks, gridApi) {
 
         // Ignore taps on UI
         if (touch.target.closest('#build-menu') ||
-            touch.target.closest('#end-turn-btn') ||
+            touch.target.closest('#bottom-bar') ||
             touch.target.closest('#race-select') ||
             touch.target.closest('#resource-bar') ||
             touch.target.closest('#turn-counter') ||
             touch.target.closest('#pop-bar') ||
-            touch.target.closest('#save-load-bar') ||
             touch.target.closest('#minimap') ||
             touch.target.closest('#pwa-install-banner') ||
             touch.target.closest('#sound-controls') ||
-            touch.target.closest('#tech-tree-btn') ||
-            touch.target.closest('#event-log-btn') ||
-            touch.target.closest('#quest-panel')) {
+            touch.target.closest('#quest-panel') ||
+            touch.target.closest('#hex-info') ||
+            touch.target.closest('#combat-log') ||
+            touch.target.closest('.hud-controls') ||
+            touch.target.closest('#tech-tree-panel') ||
+            touch.target.closest('#event-log-panel') ||
+            touch.target.closest('#event-toast') ||
+            touch.target.closest('#tutorial-overlay') ||
+            touch.target.closest('#game-over-screen') ||
+            touch.target.closest('#mp-lobby') ||
+            touch.target.closest('#mp-chat') ||
+            touch.target.closest('#mp-chat-toggle') ||
+            touch.target.closest('#anim-speed-bar') ||
+            touch.target.closest('#research-status')) {
             return;
         }
 

--- a/game-demo/js/main.js
+++ b/game-demo/js/main.js
@@ -827,12 +827,12 @@ function init() {
 
     function setupInputSystem() {
         inputApi = setupInput(camera, hexMeshes, hexData, {
-            onSelect: function (key) {
+            onSelect: async function (key) {
                 if (gameEnded) return;
                 if (isMultiplayerActive() && !getIsMyTurn()) return;
                 playClick();
                 if (key) {
-                    var unitHandled = handleUnitClick(key);
+                    var unitHandled = await handleUnitClick(key);
                     if (!unitHandled) {
                         showBuildMenu(key);
                     } else {
@@ -2090,6 +2090,8 @@ function init() {
                 hideBuildMenu();
             } else if (inputApi && inputApi.getSelectedKey()) {
                 showBuildMenu(inputApi.getSelectedKey());
+            } else {
+                showToast('story', 'Build', 'Select a hex first', '');
             }
         });
     }


### PR DESCRIPTION
Closes #54

## Changes
- Show "Select a hex first" toast when Build button is clicked with no hex selected
- Fix async/await bug in `onSelect` callback — `handleUnitClick()` is async but the result (a Promise) was never awaited, making it always truthy and preventing `showBuildMenu()` from ever firing on hex selection. This broke both the build menu AND the building upgrade/info panel.
- Replace individual button checks (`#end-turn-btn`, `#save-load-bar`, `#tech-tree-btn`, `#event-log-btn`) with single `#bottom-bar` parent check in both mouse and touch handlers to prevent all bottom bar clicks from propagating to the Three.js canvas
- Add comprehensive UI element guards (combat log, hex info, controls hint, tech tree panel, event log panel, event toast, tutorial overlay, game over screen, multiplayer UI, speed bar, research status)
- Move `.hud-controls` from `bottom: 11rem` to `bottom: 17rem` to avoid overlapping `#combat-log` (also at `bottom: 11rem`)

## Acceptance Criteria
- [x] Build button shows "Select a hex first" feedback when no hex is selected
- [x] Build menu appears correctly when a hex IS selected and Build is clicked
- [x] Building upgrade/info panel appears when clicking a hex with an existing building
- [x] Clicking any UI button does NOT change the selected hex (no click-through to canvas)
- [x] Controls hint bar does not overlap combat log
- [x] All bottom bar buttons remain functional
- [x] Works on both desktop and mobile